### PR TITLE
feat: add STS replica gating and decommission timeout for safe scale-down

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,9 @@
-<!-- Generated: 2026-05-14 | Updated: 2026-05-14 -->
+<!-- Generated: 2026-05-19 | Updated: 2026-05-19 -->
 
 # doris-operator
 
 ## Purpose
-Manages Apache Doris deployments on Kubernetes. Handles creation, configuration, and lifecycle management of Doris clusters in storage-compute-integrated mode with FE (Frontend), BE (Backend), and Broker components. Supports LDAP authentication, Vector logging, and Prometheus metrics.
+Manages Apache Doris deployments on Kubernetes. Handles creation, configuration, and lifecycle management of Doris clusters in storage-compute-integrated mode with FE (Frontend), BE (Backend), and Broker components. Supports LDAP authentication, Vector logging, Prometheus metrics, and safe scale-up/scale-down with decommission gating.
 
 ## Key Files
 | File | Description |
@@ -26,6 +26,8 @@ Manages Apache Doris deployments on Kubernetes. Handles creation, configuration,
 | `internal/controller/broker/` | Broker role reconciler (StatefulSet, ConfigMap, Service) |
 | `internal/controller/common/` | Shared resources (configmap, statefulset, service, image helper) |
 | `internal/controller/constants/` | Component constants (ports, images, paths, labels) |
+| `internal/controller/scale/` | Scale management (BE decommission/force-drop, FE drop-observer, STS gate, timeout) |
+| `internal/controller/doris_client/` | Doris MySQL protocol client for cluster management SQL operations |
 | `test/e2e/` | End-to-end test suites (chainsaw) |
 
 ## For AI Agents
@@ -58,7 +60,12 @@ Manages Apache Doris deployments on Kubernetes. Handles creation, configuration,
 - Each role creates: ConfigMap (component config) + Internal Service (headless) + Access Service + StatefulSet + Metrics Service
 - Shared logic in `common/`: `BaseDorisRoleReconciler`, `RegisterStandardResources`, `StatefulSetBuilder`
 - Broker is stateless (no PVC, no init container), FE has PVC for metadata, BE has PVC for storage + init container for sysctl
-- CRD spec uses independent fields: `spec.frontEnd`, `spec.backEnd`, `spec.broker` (type-safe, backward compatible)
+- CRD spec uses independent fields: `spec.frontend`, `spec.backend`, `spec.broker` (type-safe, backward compatible)
+- Scale management: `internal/controller/scale/` handles safe scale-down via Doris MySQL protocol
+  - STS replica gating: prevents premature pod deletion during active BE decommission
+  - Decommission timeout: automatic fallback to force-drop after configurable timeout (default 2h)
+  - Decommission start time tracked via CR annotations (`doris.kubedoop.dev/decommission-start`)
+  - FE scale-down limited to OBSERVER nodes (follower nodes are protected)
 
 ## Dependencies
 

--- a/internal/controller/doriscluster_controller.go
+++ b/internal/controller/doriscluster_controller.go
@@ -37,6 +37,7 @@ import (
 
 	dorisv1alpha1 "github.com/zncdatadev/doris-operator/api/v1alpha1"
 	"github.com/zncdatadev/operator-go/pkg/client"
+	opgpconstants "github.com/zncdatadev/operator-go/pkg/constants"
 	"github.com/zncdatadev/operator-go/pkg/reconciler"
 )
 
@@ -400,8 +401,8 @@ func (r *DorisClusterReconciler) gateBESpecReplicas(
 	// Fetch current BE StatefulSets to get actual running replica count
 	stsList := &appsv1.StatefulSetList{}
 	labelSelector := ctrlclient.MatchingLabels{
-		"app.kubernetes.io/instance":  instance.Name,
-		"app.kubernetes.io/component": string(constants.ComponentTypeBE),
+		opgpconstants.LabelKubernetesInstance:  instance.Name,
+		opgpconstants.LabelKubernetesComponent: string(constants.ComponentTypeBE),
 	}
 	if err := r.List(ctx, stsList, labelSelector, ctrlclient.InNamespace(instance.Namespace)); err != nil {
 		logger.Error(err, "Failed to list BE StatefulSets for gating", "cluster", instance.Name)
@@ -504,8 +505,8 @@ func (r *DorisClusterReconciler) fetchReplicaStates(
 	for _, ct := range []constants.ComponentType{constants.ComponentTypeFE, constants.ComponentTypeBE, constants.ComponentTypeBroker} {
 		stsList := &appsv1.StatefulSetList{}
 		labelSelector := ctrlclient.MatchingLabels{
-			"app.kubernetes.io/instance":  instance.Name,
-			"app.kubernetes.io/component": string(ct),
+			opgpconstants.LabelKubernetesInstance:  instance.Name,
+			opgpconstants.LabelKubernetesComponent: string(ct),
 		}
 		if err := r.List(ctx, stsList, labelSelector, ctrlclient.InNamespace(instance.Namespace)); err != nil {
 			return nil, fmt.Errorf("failed to list StatefulSets for %s: %w", ct, err)
@@ -553,8 +554,8 @@ func (r *DorisClusterReconciler) updateStatus(
 	buildPodNodeList := func(ct constants.ComponentType) ([]dorisv1alpha1.NodeStatus, error) {
 		podList := &corev1.PodList{}
 		labelSelector := ctrlclient.MatchingLabels{
-			"app.kubernetes.io/instance":  instance.Name,
-			"app.kubernetes.io/component": string(ct),
+			opgpconstants.LabelKubernetesInstance:  instance.Name,
+			opgpconstants.LabelKubernetesComponent: string(ct),
 		}
 		if err := r.List(ctx, podList, labelSelector, ctrlclient.InNamespace(instance.Namespace)); err != nil {
 			return nil, err

--- a/internal/controller/doriscluster_controller.go
+++ b/internal/controller/doriscluster_controller.go
@@ -32,7 +32,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -81,6 +80,14 @@ func (r *DorisClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 	logger.V(1).Info("DorisCluster found", "namespace", instance.Namespace, "name", instance.Name)
 
+	// Phase 0: Gate BE replicas if there are in-progress decommissions.
+	// By modifying the spec replicas in-memory before Phase 1, operator-go's STS
+	// reconciler will see the gated value and won't scale down prematurely.
+	gateApplied, restoreFn := r.gateBESpecReplicas(ctx, instance)
+	if gateApplied {
+		defer restoreFn()
+	}
+
 	resourceClient := &client.Client{
 		Client:         r.Client,
 		OwnerReference: instance,
@@ -126,17 +133,6 @@ func (r *DorisClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
-	// Phase 2b: Gate STS replicas — prevent premature scale-down during active decommission.
-	// operator-go's STS reconciler may have already set replicas to the desired (lower) value.
-	// If scale manager detects in-progress decommission, we patch those STS replicas back
-	// to the current count until decommission completes.
-	if scaleResult != nil && len(scaleResult.GatedReplicas) > 0 {
-		if err := r.gateSTSReplicas(ctx, instance, scaleResult.GatedReplicas); err != nil {
-			logger.Error(err, "Failed to gate STS replicas", "cluster", instance.Name)
-			return ctrl.Result{}, err
-		}
-	}
-
 	// Update CR status with node information (single status patch)
 	if err := r.updateStatus(ctx, instance, scaleResult, authInitialized); err != nil {
 		logger.Error(err, "Failed to update cluster status", "cluster", instance.Name)
@@ -153,32 +149,34 @@ func (r *DorisClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	return ctrl.Result{}, nil
 }
 
-// clusterScaleConfig implements scale.ScaleConfig by managing annotations on the DorisCluster CR.
-// It tracks BE decommission start times for timeout enforcement.
-type clusterScaleConfig struct {
+// clusterScaleDownPolicy implements scale.ScaleDownPolicy using the CR spec.
+type clusterScaleDownPolicy struct {
+	spec *dorisv1alpha1.DorisClusterSpec
+}
+
+func (p *clusterScaleDownPolicy) GetDecommissionTimeout() time.Duration {
+	return scale.GetDecommissionTimeout(p.spec)
+}
+
+// decommissionTracker implements scale.DecommissionTracker by managing annotations
+// on the DorisCluster CR to track BE decommission lifecycle.
+type decommissionTracker struct {
 	instance *dorisv1alpha1.DorisCluster
 	client   ctrlclient.Client
-	spec     *dorisv1alpha1.DorisClusterSpec
-	// pendingAnnotations stores annotation updates to be persisted
-	pendingAnnotations map[string]string
-	dirty              bool
+	// pending stores annotation mutations to be persisted: key → value (empty = delete)
+	pending map[string]string
+	dirty   bool
 }
 
-func newClusterScaleConfig(
+func newDecommissionTracker(
 	instance *dorisv1alpha1.DorisCluster,
 	client ctrlclient.Client,
-) *clusterScaleConfig {
-	return &clusterScaleConfig{
-		instance:           instance,
-		client:             client,
-		spec:               &instance.Spec,
-		pendingAnnotations: make(map[string]string),
+) *decommissionTracker {
+	return &decommissionTracker{
+		instance: instance,
+		client:   client,
+		pending:  make(map[string]string),
 	}
-}
-
-// GetDecommissionTimeout returns the configured decommission timeout duration.
-func (c *clusterScaleConfig) GetDecommissionTimeout() time.Duration {
-	return scale.GetDecommissionTimeout(c.spec)
 }
 
 // decommissionAnnoKey returns the annotation key for a pod's decommission start time.
@@ -186,33 +184,44 @@ func decommissionAnnoKey(podName string) string {
 	return fmt.Sprintf("%s/%s", scale.AnnotationDecommissionStart, podName)
 }
 
-// GetDecommissionStartAnnotation returns the recorded decommission start time for a pod.
-func (c *clusterScaleConfig) GetDecommissionStartAnnotation(podName string) (string, bool) {
+// GetStart returns the decommission start time for a pod.
+func (t *decommissionTracker) GetStart(podName string) (string, bool) {
 	key := decommissionAnnoKey(podName)
-	if val, ok := c.pendingAnnotations[key]; ok {
-		return val, ok
+	// Check pending writes first
+	if val, ok := t.pending[key]; ok {
+		return val, val != ""
 	}
-	val, ok := c.instance.Annotations[key]
+	if t.instance.Annotations == nil {
+		return "", false
+	}
+	val, ok := t.instance.Annotations[key]
 	return val, ok
 }
 
-// SetDecommissionStartAnnotation records the decommission start time for a pod.
-func (c *clusterScaleConfig) SetDecommissionStartAnnotation(podName string, timestamp string) {
-	key := decommissionAnnoKey(podName)
-	c.pendingAnnotations[key] = timestamp
-	c.dirty = true
+// RecordStart records the decommission start time for a pod.
+func (t *decommissionTracker) RecordStart(podName string, timestamp string) {
+	t.pending[decommissionAnnoKey(podName)] = timestamp
+	t.dirty = true
 }
 
-// PersistAnnotations writes any pending annotation changes to the CR.
-func (c *clusterScaleConfig) PersistAnnotations() error {
-	if !c.dirty {
+// ClearStart removes the decommission start time for a pod.
+func (t *decommissionTracker) ClearStart(podName string) {
+	key := decommissionAnnoKey(podName)
+	t.pending[key] = ""
+	t.dirty = true
+}
+
+// Persist writes all pending annotation changes to the CR.
+// Empty values in pending map are treated as deletions.
+func (t *decommissionTracker) Persist(ctx context.Context) error {
+	if !t.dirty {
 		return nil
 	}
 
 	latest := &dorisv1alpha1.DorisCluster{}
-	if err := c.client.Get(context.Background(), types.NamespacedName{
-		Name:      c.instance.Name,
-		Namespace: c.instance.Namespace,
+	if err := t.client.Get(ctx, types.NamespacedName{
+		Name:      t.instance.Name,
+		Namespace: t.instance.Namespace,
 	}, latest); err != nil {
 		return fmt.Errorf("failed to fetch latest CR for annotation update: %w", err)
 	}
@@ -221,24 +230,54 @@ func (c *clusterScaleConfig) PersistAnnotations() error {
 	if latest.Annotations == nil {
 		latest.Annotations = make(map[string]string)
 	}
-	for k, v := range c.pendingAnnotations {
-		latest.Annotations[k] = v
+
+	var persisted, deleted int
+	for k, v := range t.pending {
+		if v == "" {
+			delete(latest.Annotations, k)
+			deleted++
+		} else {
+			latest.Annotations[k] = v
+			persisted++
+		}
 	}
 
-	if err := c.client.Patch(context.Background(), latest, patch); err != nil {
+	if err := t.client.Patch(ctx, latest, patch); err != nil {
 		return fmt.Errorf("failed to persist decommission annotations: %w", err)
 	}
 
-	// Update local reference so subsequent reads in this reconcile are consistent
-	c.instance = latest
-	c.dirty = false
-	logger.Info("Persisted decommission start annotations", "count", len(c.pendingAnnotations))
+	t.instance = latest
+	t.dirty = false
+	t.pending = make(map[string]string)
+	logger.Info("Persisted decommission annotations", "recorded", persisted, "cleared", deleted)
 	return nil
+}
+
+// PendingPods returns pod names that have active decommission tracking annotations.
+// These pods are in the middle of decommission and their STS replicas should be gated.
+func (t *decommissionTracker) PendingPods() []string {
+	if t.instance.Annotations == nil {
+		return nil
+	}
+
+	prefix := scale.AnnotationDecommissionStart + "/"
+	var pods []string
+	for key := range t.instance.Annotations {
+		if len(key) > len(prefix) && key[:len(prefix)] == prefix {
+			podName := key[len(prefix):]
+			// Check if this pod was cleared in pending
+			if val, ok := t.pending[decommissionAnnoKey(podName)]; ok && val == "" {
+				continue
+			}
+			pods = append(pods, podName)
+		}
+	}
+	return pods
 }
 
 // reconcileScale performs scale reconciliation by connecting to Doris FE
 // and checking if any scale-down operations are needed.
-// It returns the scale result and an optional authInitialized flag.
+// It returns the scale result and whether auth bootstrap was performed.
 func (r *DorisClusterReconciler) reconcileScale(
 	ctx context.Context,
 	instance *dorisv1alpha1.DorisCluster,
@@ -274,7 +313,6 @@ func (r *DorisClusterReconciler) reconcileScale(
 	}
 
 	// Bootstrap the admin user with root credentials if needed.
-	// This is only done once when authSecret is first configured.
 	if needBootstrap {
 		rootClient, err := doris_client.NewDorisClient(feHost, constants.FEQueryPort, doris_client.DefaultAdminUser, "")
 		if err != nil {
@@ -317,21 +355,142 @@ func (r *DorisClusterReconciler) reconcileScale(
 		return nil, false, fmt.Errorf("failed to fetch replica states: %w", err)
 	}
 
-	// Create scale config for decommission timeout tracking
-	scaleConfig := newClusterScaleConfig(instance, r.Client)
+	// Create policy and tracker for decommission lifecycle management
+	policy := &clusterScaleDownPolicy{spec: &instance.Spec}
+	tracker := newDecommissionTracker(instance, r.Client)
 
-	result, err := scaleMgr.ReconcileScale(ctx, &instance.Spec, replicaStates, scaleConfig)
+	result, err := scaleMgr.ReconcileScale(ctx, &instance.Spec, replicaStates, policy, tracker)
 	if err != nil {
 		return nil, false, err
 	}
 
-	// Persist decommission start time annotations if any were set
-	if err := scaleConfig.PersistAnnotations(); err != nil {
+	// Persist decommission annotation changes (records + clears)
+	if err := tracker.Persist(ctx); err != nil {
 		logger.Error(err, "Failed to persist decommission annotations", "cluster", instance.Name)
-		// Non-fatal: decommission timeout tracking will be approximate
+		// Non-fatal: decommission timeout tracking will be approximate until next persistence
 	}
 
 	return result, needBootstrap, nil
+}
+
+// gateBESpecReplicas checks for in-progress BE decommissions (via CR annotations)
+// and gates the BE spec replicas to the current STS replica count. This prevents
+// operator-go's STS reconciler from scaling down pods during active decommission.
+//
+// It returns whether a gate was applied and a restore function that must be called
+// (typically via defer) to restore the original spec values.
+//
+// This is the "pre-reconcile interception" approach: by modifying the spec in-memory
+// before Phase 1, the STS builder sees the gated replicas and won't create an update
+// that would trigger premature pod deletion.
+func (r *DorisClusterReconciler) gateBESpecReplicas(
+	ctx context.Context,
+	instance *dorisv1alpha1.DorisCluster,
+) (bool, func()) {
+	if instance.Spec.Backend == nil {
+		return false, func() {}
+	}
+
+	tracker := newDecommissionTracker(instance, r.Client)
+	pendingPods := tracker.PendingPods()
+	if len(pendingPods) == 0 {
+		return false, func() {}
+	}
+
+	// Fetch current BE StatefulSets to get actual running replica count
+	stsList := &appsv1.StatefulSetList{}
+	labelSelector := ctrlclient.MatchingLabels{
+		"app.kubernetes.io/instance":  instance.Name,
+		"app.kubernetes.io/component": string(constants.ComponentTypeBE),
+	}
+	if err := r.List(ctx, stsList, labelSelector, ctrlclient.InNamespace(instance.Namespace)); err != nil {
+		logger.Error(err, "Failed to list BE StatefulSets for gating", "cluster", instance.Name)
+		return false, func() {}
+	}
+
+	if len(stsList.Items) == 0 {
+		return false, func() {}
+	}
+
+	// Sum up current running replicas across all BE STSs
+	var currentReplicas int32
+	for _, sts := range stsList.Items {
+		currentReplicas += sts.Status.Replicas
+	}
+
+	// Check if gating is actually needed (current > desired)
+	desired := scale.GetEffectiveReplicas(instance.Spec.Backend)
+	if currentReplicas <= desired {
+		return false, func() {}
+	}
+
+	logger.Info("Gating BE spec replicas for in-progress decommission",
+		"cluster", instance.Name,
+		"desired", desired,
+		"current", currentReplicas,
+		"pendingPods", pendingPods)
+
+	// For single roleGroup: override replicas directly
+	// For multi roleGroup: gate proportionally across groups (best-effort)
+	if len(instance.Spec.Backend.RoleGroups) == 1 {
+		for name, rg := range instance.Spec.Backend.RoleGroups {
+			original := rg.Replicas
+			rg.Replicas = &currentReplicas
+			return true, func() {
+				logger.V(1).Info("Restoring BE spec replicas after gate",
+					"cluster", instance.Name, "roleGroup", name,
+					"restored", original, "gated", currentReplicas)
+				rg.Replicas = original
+			}
+		}
+	}
+
+	// Multi-roleGroup: gate proportionally by distributing the current total
+	// across groups weighted by their desired replicas
+	totalDesired := desired
+	if totalDesired == 0 {
+		return false, func() {}
+	}
+
+	originals := make(map[string]int32)
+	remaining := currentReplicas
+	groupNames := make([]string, 0, len(instance.Spec.Backend.RoleGroups))
+	for name := range instance.Spec.Backend.RoleGroups {
+		groupNames = append(groupNames, name)
+	}
+
+	for i, name := range groupNames {
+		rg := instance.Spec.Backend.RoleGroups[name]
+		original := int32(0)
+		if rg.Replicas != nil {
+			original = *rg.Replicas
+		}
+		originals[name] = original
+
+		groupDesired := original
+
+		var gated int32
+		if i == len(groupNames)-1 {
+			// Last group gets the remainder to avoid rounding drift
+			gated = remaining
+		} else {
+			gated = currentReplicas * groupDesired / totalDesired
+			if gated < 1 {
+				gated = 1
+			}
+		}
+		remaining -= gated
+		rg.Replicas = &gated
+		instance.Spec.Backend.RoleGroups[name] = rg
+	}
+
+	return true, func() {
+		for name, original := range originals {
+			rg := instance.Spec.Backend.RoleGroups[name]
+			rg.Replicas = &original
+			instance.Spec.Backend.RoleGroups[name] = rg
+		}
+	}
 }
 
 // fetchReplicaStates builds replica states for all cluster components
@@ -362,7 +521,7 @@ func (r *DorisClusterReconciler) fetchReplicaStates(
 			rs.CurrentReplicas += sts.Status.Replicas
 			rs.ReadyReplicas += sts.Status.ReadyReplicas
 			rs.PodNames = append(rs.PodNames, scale.GetStatefulSetPodNames(&sts)...)
-			rs.StSNames = append(rs.StSNames, sts.Name)
+			rs.StatefulSetNames = append(rs.StatefulSetNames, sts.Name)
 		}
 		states[ct] = rs
 	}
@@ -370,50 +529,8 @@ func (r *DorisClusterReconciler) fetchReplicaStates(
 	return states, nil
 }
 
-// gateSTSReplicas patches StatefulSets to hold their replica count at the gated value,
-// preventing operator-go's STS reconciler from scaling down pods while decommission is active.
-// This is the "post-reconcile correction" that implements the scale-down safety gate.
-func (r *DorisClusterReconciler) gateSTSReplicas(
-	ctx context.Context,
-	instance *dorisv1alpha1.DorisCluster,
-	gatedReplicas map[string]int32,
-) error {
-	for stsName, minReplicas := range gatedReplicas {
-		sts := &appsv1.StatefulSet{}
-		if err := r.Get(ctx, types.NamespacedName{
-			Name:      stsName,
-			Namespace: instance.Namespace,
-		}, sts); err != nil {
-			if ctrlclient.IgnoreNotFound(err) == nil {
-				logger.V(1).Info("Gated STS not found, skipping", "sts", stsName)
-				continue
-			}
-			return fmt.Errorf("failed to get gated STS %s: %w", stsName, err)
-		}
-
-		currentReplicas := int32(1)
-		if sts.Spec.Replicas != nil {
-			currentReplicas = *sts.Spec.Replicas
-		}
-
-		if currentReplicas < minReplicas {
-			logger.Info("Gating STS replicas to prevent premature scale-down",
-				"sts", stsName,
-				"current", currentReplicas,
-				"gated", minReplicas)
-			patch := ctrlclient.MergeFrom(sts.DeepCopy())
-			sts.Spec.Replicas = ptr.To(minReplicas)
-			if err := r.Patch(ctx, sts, patch); err != nil {
-				return fmt.Errorf("failed to gate STS %s replicas to %d: %w", stsName, minReplicas, err)
-			}
-		}
-	}
-	return nil
-}
-
 // updateStatus patches the DorisCluster status in a single patch operation.
 // When scaleResult is nil (e.g., BE not yet alive), it falls back to pod-list-based status.
-// When authBootstrap is true, it also sets AuthInitialized = true.
 func (r *DorisClusterReconciler) updateStatus(
 	ctx context.Context,
 	instance *dorisv1alpha1.DorisCluster,
@@ -455,7 +572,6 @@ func (r *DorisClusterReconciler) updateStatus(
 	if result != nil {
 		scale.UpdateClusterStatus(&latest.Status, result.BEStatuses, result.FEStatuses, result.BrokerStatuses)
 
-		// Fallback to pod listing for components where SQL query failed (nil statuses)
 		if result.BEStatuses == nil {
 			if nodes, err := buildPodNodeList(constants.ComponentTypeBE); err != nil {
 				return err
@@ -478,7 +594,6 @@ func (r *DorisClusterReconciler) updateStatus(
 			}
 		}
 	} else {
-		// Full fallback: build status from pod listings for all components
 		for _, ct := range []constants.ComponentType{constants.ComponentTypeFE, constants.ComponentTypeBE, constants.ComponentTypeBroker} {
 			nodes, err := buildPodNodeList(ct)
 			if err != nil {

--- a/internal/controller/doriscluster_controller.go
+++ b/internal/controller/doriscluster_controller.go
@@ -394,11 +394,14 @@ func (r *DorisClusterReconciler) gateBESpecReplicas(
 		return false, func() {}
 	}
 
-	// Gate if there are in-progress decommissions (from annotations)
-	// OR if STS replicas exceed the spec desired count (first-reconcile case
-	// where annotations haven't been written yet).
+	// Gate if there are in-progress decommissions (from CR annotations).
+	// Once Phase 2 records decommission-start annotations, subsequent reconciles
+	// will gate here to prevent STS from scaling down before decommission completes.
 	tracker := newDecommissionTracker(instance, r.Client)
 	hasPending := len(tracker.PendingPods()) > 0
+	if !hasPending {
+		return false, func() {}
+	}
 
 	// Fetch current BE StatefulSets to detect scale-down intent
 	stsList := &appsv1.StatefulSetList{}
@@ -427,21 +430,11 @@ func (r *DorisClusterReconciler) gateBESpecReplicas(
 		return false, func() {}
 	}
 
-	if !hasPending {
-		// First reconcile after scale-down intent detected but no annotations yet.
-		// This is the critical window: Phase 1 would scale down before Phase 2 records
-		// decommission-start annotations. Gate now to prevent premature deletion.
-		logger.Info("Gating BE spec replicas on first scale-down detection",
-			"cluster", instance.Name,
-			"desired", desired,
-			"current", currentReplicas)
-	} else {
-		logger.Info("Gating BE spec replicas for in-progress decommission",
-			"cluster", instance.Name,
-			"desired", desired,
-			"current", currentReplicas,
-			"pendingPods", tracker.PendingPods())
-	}
+	logger.Info("Gating BE spec replicas for in-progress decommission",
+		"cluster", instance.Name,
+		"desired", desired,
+		"current", currentReplicas,
+		"pendingPods", tracker.PendingPods())
 
 	// For single roleGroup: override replicas directly
 	if len(instance.Spec.Backend.RoleGroups) == 1 {

--- a/internal/controller/doriscluster_controller.go
+++ b/internal/controller/doriscluster_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/go-logr/logr"
 
@@ -31,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -118,11 +120,21 @@ func (r *DorisClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// Phase 2: Scale management (after resources are ready)
-	// TODO: Gate StatefulSet replica decrease behind scale manager to ensure safe scale-down
 	scaleResult, authInitialized, err := r.reconcileScale(ctx, instance)
 	if err != nil {
 		logger.Error(err, "Scale reconciliation failed", "cluster", instance.Name)
 		return ctrl.Result{}, nil
+	}
+
+	// Phase 2b: Gate STS replicas — prevent premature scale-down during active decommission.
+	// operator-go's STS reconciler may have already set replicas to the desired (lower) value.
+	// If scale manager detects in-progress decommission, we patch those STS replicas back
+	// to the current count until decommission completes.
+	if scaleResult != nil && len(scaleResult.GatedReplicas) > 0 {
+		if err := r.gateSTSReplicas(ctx, instance, scaleResult.GatedReplicas); err != nil {
+			logger.Error(err, "Failed to gate STS replicas", "cluster", instance.Name)
+			return ctrl.Result{}, err
+		}
 	}
 
 	// Update CR status with node information (single status patch)
@@ -139,6 +151,89 @@ func (r *DorisClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	logger.V(1).Info("Reconcile finished.", "cluster", instance.Name, "namespace", instance.Namespace)
 
 	return ctrl.Result{}, nil
+}
+
+// clusterScaleConfig implements scale.ScaleConfig by managing annotations on the DorisCluster CR.
+// It tracks BE decommission start times for timeout enforcement.
+type clusterScaleConfig struct {
+	instance *dorisv1alpha1.DorisCluster
+	client   ctrlclient.Client
+	spec     *dorisv1alpha1.DorisClusterSpec
+	// pendingAnnotations stores annotation updates to be persisted
+	pendingAnnotations map[string]string
+	dirty              bool
+}
+
+func newClusterScaleConfig(
+	instance *dorisv1alpha1.DorisCluster,
+	client ctrlclient.Client,
+) *clusterScaleConfig {
+	return &clusterScaleConfig{
+		instance:           instance,
+		client:             client,
+		spec:               &instance.Spec,
+		pendingAnnotations: make(map[string]string),
+	}
+}
+
+// GetDecommissionTimeout returns the configured decommission timeout duration.
+func (c *clusterScaleConfig) GetDecommissionTimeout() time.Duration {
+	return scale.GetDecommissionTimeout(c.spec)
+}
+
+// decommissionAnnoKey returns the annotation key for a pod's decommission start time.
+func decommissionAnnoKey(podName string) string {
+	return fmt.Sprintf("%s/%s", scale.AnnotationDecommissionStart, podName)
+}
+
+// GetDecommissionStartAnnotation returns the recorded decommission start time for a pod.
+func (c *clusterScaleConfig) GetDecommissionStartAnnotation(podName string) (string, bool) {
+	key := decommissionAnnoKey(podName)
+	if val, ok := c.pendingAnnotations[key]; ok {
+		return val, ok
+	}
+	val, ok := c.instance.Annotations[key]
+	return val, ok
+}
+
+// SetDecommissionStartAnnotation records the decommission start time for a pod.
+func (c *clusterScaleConfig) SetDecommissionStartAnnotation(podName string, timestamp string) {
+	key := decommissionAnnoKey(podName)
+	c.pendingAnnotations[key] = timestamp
+	c.dirty = true
+}
+
+// PersistAnnotations writes any pending annotation changes to the CR.
+func (c *clusterScaleConfig) PersistAnnotations() error {
+	if !c.dirty {
+		return nil
+	}
+
+	latest := &dorisv1alpha1.DorisCluster{}
+	if err := c.client.Get(context.Background(), types.NamespacedName{
+		Name:      c.instance.Name,
+		Namespace: c.instance.Namespace,
+	}, latest); err != nil {
+		return fmt.Errorf("failed to fetch latest CR for annotation update: %w", err)
+	}
+
+	patch := ctrlclient.MergeFrom(latest.DeepCopy())
+	if latest.Annotations == nil {
+		latest.Annotations = make(map[string]string)
+	}
+	for k, v := range c.pendingAnnotations {
+		latest.Annotations[k] = v
+	}
+
+	if err := c.client.Patch(context.Background(), latest, patch); err != nil {
+		return fmt.Errorf("failed to persist decommission annotations: %w", err)
+	}
+
+	// Update local reference so subsequent reads in this reconcile are consistent
+	c.instance = latest
+	c.dirty = false
+	logger.Info("Persisted decommission start annotations", "count", len(c.pendingAnnotations))
+	return nil
 }
 
 // reconcileScale performs scale reconciliation by connecting to Doris FE
@@ -222,9 +317,18 @@ func (r *DorisClusterReconciler) reconcileScale(
 		return nil, false, fmt.Errorf("failed to fetch replica states: %w", err)
 	}
 
-	result, err := scaleMgr.ReconcileScale(ctx, &instance.Spec, replicaStates)
+	// Create scale config for decommission timeout tracking
+	scaleConfig := newClusterScaleConfig(instance, r.Client)
+
+	result, err := scaleMgr.ReconcileScale(ctx, &instance.Spec, replicaStates, scaleConfig)
 	if err != nil {
 		return nil, false, err
+	}
+
+	// Persist decommission start time annotations if any were set
+	if err := scaleConfig.PersistAnnotations(); err != nil {
+		logger.Error(err, "Failed to persist decommission annotations", "cluster", instance.Name)
+		// Non-fatal: decommission timeout tracking will be approximate
 	}
 
 	return result, needBootstrap, nil
@@ -258,11 +362,53 @@ func (r *DorisClusterReconciler) fetchReplicaStates(
 			rs.CurrentReplicas += sts.Status.Replicas
 			rs.ReadyReplicas += sts.Status.ReadyReplicas
 			rs.PodNames = append(rs.PodNames, scale.GetStatefulSetPodNames(&sts)...)
+			rs.StSNames = append(rs.StSNames, sts.Name)
 		}
 		states[ct] = rs
 	}
 
 	return states, nil
+}
+
+// gateSTSReplicas patches StatefulSets to hold their replica count at the gated value,
+// preventing operator-go's STS reconciler from scaling down pods while decommission is active.
+// This is the "post-reconcile correction" that implements the scale-down safety gate.
+func (r *DorisClusterReconciler) gateSTSReplicas(
+	ctx context.Context,
+	instance *dorisv1alpha1.DorisCluster,
+	gatedReplicas map[string]int32,
+) error {
+	for stsName, minReplicas := range gatedReplicas {
+		sts := &appsv1.StatefulSet{}
+		if err := r.Get(ctx, types.NamespacedName{
+			Name:      stsName,
+			Namespace: instance.Namespace,
+		}, sts); err != nil {
+			if ctrlclient.IgnoreNotFound(err) == nil {
+				logger.V(1).Info("Gated STS not found, skipping", "sts", stsName)
+				continue
+			}
+			return fmt.Errorf("failed to get gated STS %s: %w", stsName, err)
+		}
+
+		currentReplicas := int32(1)
+		if sts.Spec.Replicas != nil {
+			currentReplicas = *sts.Spec.Replicas
+		}
+
+		if currentReplicas < minReplicas {
+			logger.Info("Gating STS replicas to prevent premature scale-down",
+				"sts", stsName,
+				"current", currentReplicas,
+				"gated", minReplicas)
+			patch := ctrlclient.MergeFrom(sts.DeepCopy())
+			sts.Spec.Replicas = ptr.To(minReplicas)
+			if err := r.Patch(ctx, sts, patch); err != nil {
+				return fmt.Errorf("failed to gate STS %s replicas to %d: %w", stsName, minReplicas, err)
+			}
+		}
+	}
+	return nil
 }
 
 // updateStatus patches the DorisCluster status in a single patch operation.

--- a/internal/controller/doriscluster_controller.go
+++ b/internal/controller/doriscluster_controller.go
@@ -254,8 +254,9 @@ func (t *decommissionTracker) Persist(ctx context.Context) error {
 	return nil
 }
 
-// PendingPods returns pod names that have active decommission tracking annotations.
+// PendingPods returns pod names that have active (non-cleared) decommission tracking.
 // These pods are in the middle of decommission and their STS replicas should be gated.
+// Results are sorted for deterministic behavior.
 func (t *decommissionTracker) PendingPods() []string {
 	if t.instance.Annotations == nil {
 		return nil
@@ -273,6 +274,7 @@ func (t *decommissionTracker) PendingPods() []string {
 			pods = append(pods, podName)
 		}
 	}
+	sort.Strings(pods)
 	return pods
 }
 
@@ -392,13 +394,13 @@ func (r *DorisClusterReconciler) gateBESpecReplicas(
 		return false, func() {}
 	}
 
+	// Gate if there are in-progress decommissions (from annotations)
+	// OR if STS replicas exceed the spec desired count (first-reconcile case
+	// where annotations haven't been written yet).
 	tracker := newDecommissionTracker(instance, r.Client)
-	pendingPods := tracker.PendingPods()
-	if len(pendingPods) == 0 {
-		return false, func() {}
-	}
+	hasPending := len(tracker.PendingPods()) > 0
 
-	// Fetch current BE StatefulSets to get actual running replica count
+	// Fetch current BE StatefulSets to detect scale-down intent
 	stsList := &appsv1.StatefulSetList{}
 	labelSelector := ctrlclient.MatchingLabels{
 		opgpconstants.LabelKubernetesInstance:  instance.Name,
@@ -425,29 +427,46 @@ func (r *DorisClusterReconciler) gateBESpecReplicas(
 		return false, func() {}
 	}
 
-	logger.Info("Gating BE spec replicas for in-progress decommission",
-		"cluster", instance.Name,
-		"desired", desired,
-		"current", currentReplicas,
-		"pendingPods", pendingPods)
+	if !hasPending {
+		// First reconcile after scale-down intent detected but no annotations yet.
+		// This is the critical window: Phase 1 would scale down before Phase 2 records
+		// decommission-start annotations. Gate now to prevent premature deletion.
+		logger.Info("Gating BE spec replicas on first scale-down detection",
+			"cluster", instance.Name,
+			"desired", desired,
+			"current", currentReplicas)
+	} else {
+		logger.Info("Gating BE spec replicas for in-progress decommission",
+			"cluster", instance.Name,
+			"desired", desired,
+			"current", currentReplicas,
+			"pendingPods", tracker.PendingPods())
+	}
 
 	// For single roleGroup: override replicas directly
-	// For multi roleGroup: gate proportionally across groups (best-effort)
 	if len(instance.Spec.Backend.RoleGroups) == 1 {
-		for name, rg := range instance.Spec.Backend.RoleGroups {
+		for name := range instance.Spec.Backend.RoleGroups {
+			rg := instance.Spec.Backend.RoleGroups[name]
 			original := rg.Replicas
-			rg.Replicas = &currentReplicas
+
+			// Allocate a stable variable for the gated value (not a loop-local)
+			gated := currentReplicas
+			rg.Replicas = &gated
+			instance.Spec.Backend.RoleGroups[name] = rg
+
 			return true, func() {
 				logger.V(1).Info("Restoring BE spec replicas after gate",
 					"cluster", instance.Name, "roleGroup", name,
-					"restored", original, "gated", currentReplicas)
+					"restored", original, "gated", gated)
+				rg := instance.Spec.Backend.RoleGroups[name]
 				rg.Replicas = original
+				instance.Spec.Backend.RoleGroups[name] = rg
 			}
 		}
 	}
 
 	// Multi-roleGroup: gate proportionally by distributing the current total
-	// across groups weighted by their desired replicas
+	// across groups weighted by their desired replicas.
 	totalDesired := desired
 	if totalDesired == 0 {
 		return false, func() {}
@@ -472,7 +491,6 @@ func (r *DorisClusterReconciler) gateBESpecReplicas(
 
 		var gated int32
 		if i == len(groupNames)-1 {
-			// Last group gets the remainder to avoid rounding drift
 			gated = remaining
 		} else {
 			gated = currentReplicas * groupDesired / totalDesired
@@ -481,14 +499,18 @@ func (r *DorisClusterReconciler) gateBESpecReplicas(
 			}
 		}
 		remaining -= gated
-		rg.Replicas = &gated
+
+		// Allocate stable per-group variable for gated value
+		gatedCopy := gated
+		rg.Replicas = &gatedCopy
 		instance.Spec.Backend.RoleGroups[name] = rg
 	}
 
 	return true, func() {
 		for name, original := range originals {
 			rg := instance.Spec.Backend.RoleGroups[name]
-			rg.Replicas = &original
+			restoreCopy := original
+			rg.Replicas = &restoreCopy
 			instance.Spec.Backend.RoleGroups[name] = rg
 		}
 	}

--- a/internal/controller/doriscluster_controller_test.go
+++ b/internal/controller/doriscluster_controller_test.go
@@ -18,17 +18,25 @@ package controller
 
 import (
 	"testing"
+	"time"
 
 	dorisv1alpha1 "github.com/zncdatadev/doris-operator/api/v1alpha1"
 	"github.com/zncdatadev/doris-operator/internal/controller/scale"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	testClusterName      = "test"
+	testClusterNamespace = "default"
+	testTimestamp        = "2026-05-19T10:00:00Z"
+	testAnnoBE0          = "doris.kubedoop.dev/decommission-start/be-0"
+)
+
 func TestDecommissionTracker_GetStart(t *testing.T) {
 	instance := &dorisv1alpha1.DorisCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test",
-			Namespace:   "default",
+			Name:        testClusterName,
+			Namespace:   testClusterNamespace,
 			Annotations: map[string]string{},
 		},
 	}
@@ -41,9 +49,9 @@ func TestDecommissionTracker_GetStart(t *testing.T) {
 	}
 
 	// Set and read back
-	tracker.RecordStart("be-0", "2026-05-19T10:00:00Z")
+	tracker.RecordStart("be-0", testTimestamp)
 	val, ok := tracker.GetStart("be-0")
-	if !ok || val != "2026-05-19T10:00:00Z" {
+	if !ok || val != testTimestamp {
 		t.Errorf("expected recorded start, got val=%q ok=%v", val, ok)
 	}
 
@@ -70,7 +78,7 @@ func TestDecommissionTracker_PendingPods(t *testing.T) {
 		{
 			name: "active decommission",
 			annotations: map[string]string{
-				"doris.kubedoop.dev/decommission-start/be-0": "2026-05-19T10:00:00Z",
+				testAnnoBE0: testTimestamp,
 				"doris.kubedoop.dev/decommission-start/be-1": "2026-05-19T10:01:00Z",
 			},
 			want: []string{"be-0", "be-1"},
@@ -78,29 +86,29 @@ func TestDecommissionTracker_PendingPods(t *testing.T) {
 		{
 			name: "cleared in pending",
 			annotations: map[string]string{
-				"doris.kubedoop.dev/decommission-start/be-0": "2026-05-19T10:00:00Z",
+				testAnnoBE0: testTimestamp,
 			},
 			pending: map[string]string{
-				"doris.kubedoop.dev/decommission-start/be-0": "", // cleared
+				testAnnoBE0: "", // cleared
 			},
 			want: nil,
 		},
 		{
 			name: "mixed - one active one cleared",
 			annotations: map[string]string{
-				"doris.kubedoop.dev/decommission-start/be-0": "2026-05-19T10:00:00Z",
+				testAnnoBE0: testTimestamp,
 				"doris.kubedoop.dev/decommission-start/be-1": "2026-05-19T10:01:00Z",
 			},
 			pending: map[string]string{
-				"doris.kubedoop.dev/decommission-start/be-0": "",
+				testAnnoBE0: "",
 			},
 			want: []string{"be-1"},
 		},
 		{
 			name: "unrelated annotation ignored",
 			annotations: map[string]string{
-				"doris.kubedoop.dev/decommission-start/be-0": "2026-05-19T10:00:00Z",
-				"some.other/annotation":                      "value",
+				testAnnoBE0:             testTimestamp,
+				"some.other/annotation": "value",
 			},
 			want: []string{"be-0"},
 		},
@@ -110,8 +118,8 @@ func TestDecommissionTracker_PendingPods(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			instance := &dorisv1alpha1.DorisCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "test",
-					Namespace:   "default",
+					Name:        testClusterName,
+					Namespace:   testClusterNamespace,
 					Annotations: tt.annotations,
 				},
 			}
@@ -135,7 +143,7 @@ func TestDecommissionTracker_PendingPods(t *testing.T) {
 
 func TestDecommissionTracker_Dirty(t *testing.T) {
 	instance := &dorisv1alpha1.DorisCluster{
-		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: testClusterName, Namespace: testClusterNamespace},
 	}
 	tracker := newDecommissionTracker(instance, nil)
 
@@ -143,7 +151,7 @@ func TestDecommissionTracker_Dirty(t *testing.T) {
 		t.Error("expected clean tracker on init")
 	}
 
-	tracker.RecordStart("be-0", "2026-05-19T10:00:00Z")
+	tracker.RecordStart("be-0", testTimestamp)
 	if !tracker.dirty {
 		t.Error("expected dirty after RecordStart")
 	}
@@ -163,10 +171,10 @@ func TestGateBESpecReplicas_SingleRoleGroup(t *testing.T) {
 
 	instance := &dorisv1alpha1.DorisCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "default",
+			Name:      testClusterName,
+			Namespace: testClusterNamespace,
 			Annotations: map[string]string{
-				"doris.kubedoop.dev/decommission-start/be-2": "2026-05-19T10:00:00Z",
+				"doris.kubedoop.dev/decommission-start/be-2": testTimestamp,
 			},
 		},
 		Spec: dorisv1alpha1.DorisClusterSpec{
@@ -206,10 +214,10 @@ func TestGateBESpecReplicas_MultiRoleGroup(t *testing.T) {
 
 	instance := &dorisv1alpha1.DorisCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "default",
+			Name:      testClusterName,
+			Namespace: testClusterNamespace,
 			Annotations: map[string]string{
-				"doris.kubedoop.dev/decommission-start/be-2": "2026-05-19T10:00:00Z",
+				"doris.kubedoop.dev/decommission-start/be-2": testTimestamp,
 			},
 		},
 		Spec: dorisv1alpha1.DorisClusterSpec{
@@ -281,19 +289,19 @@ func TestScaleDownPolicy_Timeout(t *testing.T) {
 	policy := &clusterScaleDownPolicy{spec: spec}
 
 	timeout := policy.GetDecommissionTimeout()
-	if timeout != 2*1000000000*3600 { // 2h in nanoseconds
+	if timeout != 2*time.Hour {
 		t.Errorf("expected 2h default timeout, got %v", timeout)
 	}
 
 	// Custom timeout
-	custom := metav1.Duration{Duration: 30 * 60 * 1000000000} // 30 minutes
+	custom := metav1.Duration{Duration: 30 * time.Minute}
 	spec.ClusterConfig = &dorisv1alpha1.ClusterConfigSpec{
 		ScaleDownPolicy: &dorisv1alpha1.ScaleDownPolicySpec{
 			DecommissionTimeout: &custom,
 		},
 	}
 	timeout = policy.GetDecommissionTimeout()
-	if timeout != 30*60*1000000000 {
+	if timeout != 30*time.Minute {
 		t.Errorf("expected 30m custom timeout, got %v", timeout)
 	}
 }

--- a/internal/controller/doriscluster_controller_test.go
+++ b/internal/controller/doriscluster_controller_test.go
@@ -1,0 +1,305 @@
+/*
+Copyright 2025 zncdatadev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	dorisv1alpha1 "github.com/zncdatadev/doris-operator/api/v1alpha1"
+	"github.com/zncdatadev/doris-operator/internal/controller/scale"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDecommissionTracker_GetStart(t *testing.T) {
+	instance := &dorisv1alpha1.DorisCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test",
+			Namespace:   "default",
+			Annotations: map[string]string{},
+		},
+	}
+	tracker := newDecommissionTracker(instance, nil)
+
+	// No annotation → not found
+	_, ok := tracker.GetStart("be-0")
+	if ok {
+		t.Error("expected false for missing annotation")
+	}
+
+	// Set and read back
+	tracker.RecordStart("be-0", "2026-05-19T10:00:00Z")
+	val, ok := tracker.GetStart("be-0")
+	if !ok || val != "2026-05-19T10:00:00Z" {
+		t.Errorf("expected recorded start, got val=%q ok=%v", val, ok)
+	}
+
+	// Clear
+	tracker.ClearStart("be-0")
+	_, ok = tracker.GetStart("be-0")
+	if ok {
+		t.Error("expected false after clear")
+	}
+}
+
+func TestDecommissionTracker_PendingPods(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		pending     map[string]string
+		want        []string
+	}{
+		{
+			name:        "no annotations",
+			annotations: nil,
+			want:        nil,
+		},
+		{
+			name: "active decommission",
+			annotations: map[string]string{
+				"doris.kubedoop.dev/decommission-start/be-0": "2026-05-19T10:00:00Z",
+				"doris.kubedoop.dev/decommission-start/be-1": "2026-05-19T10:01:00Z",
+			},
+			want: []string{"be-0", "be-1"},
+		},
+		{
+			name: "cleared in pending",
+			annotations: map[string]string{
+				"doris.kubedoop.dev/decommission-start/be-0": "2026-05-19T10:00:00Z",
+			},
+			pending: map[string]string{
+				"doris.kubedoop.dev/decommission-start/be-0": "", // cleared
+			},
+			want: nil,
+		},
+		{
+			name: "mixed - one active one cleared",
+			annotations: map[string]string{
+				"doris.kubedoop.dev/decommission-start/be-0": "2026-05-19T10:00:00Z",
+				"doris.kubedoop.dev/decommission-start/be-1": "2026-05-19T10:01:00Z",
+			},
+			pending: map[string]string{
+				"doris.kubedoop.dev/decommission-start/be-0": "",
+			},
+			want: []string{"be-1"},
+		},
+		{
+			name: "unrelated annotation ignored",
+			annotations: map[string]string{
+				"doris.kubedoop.dev/decommission-start/be-0": "2026-05-19T10:00:00Z",
+				"some.other/annotation":                      "value",
+			},
+			want: []string{"be-0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := &dorisv1alpha1.DorisCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test",
+					Namespace:   "default",
+					Annotations: tt.annotations,
+				},
+			}
+			tracker := newDecommissionTracker(instance, nil)
+			if tt.pending != nil {
+				tracker.pending = tt.pending
+			}
+			got := tracker.PendingPods()
+			if len(got) != len(tt.want) {
+				t.Errorf("PendingPods() len = %d, want %d", len(got), len(tt.want))
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("PendingPods()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDecommissionTracker_Dirty(t *testing.T) {
+	instance := &dorisv1alpha1.DorisCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+	}
+	tracker := newDecommissionTracker(instance, nil)
+
+	if tracker.dirty {
+		t.Error("expected clean tracker on init")
+	}
+
+	tracker.RecordStart("be-0", "2026-05-19T10:00:00Z")
+	if !tracker.dirty {
+		t.Error("expected dirty after RecordStart")
+	}
+
+	tracker.pending = make(map[string]string)
+	tracker.dirty = false
+
+	tracker.ClearStart("be-0")
+	if !tracker.dirty {
+		t.Error("expected dirty after ClearStart")
+	}
+}
+
+func TestGateBESpecReplicas_SingleRoleGroup(t *testing.T) {
+	desired := int32(2)
+	current := int32(3)
+
+	instance := &dorisv1alpha1.DorisCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"doris.kubedoop.dev/decommission-start/be-2": "2026-05-19T10:00:00Z",
+			},
+		},
+		Spec: dorisv1alpha1.DorisClusterSpec{
+			Backend: &dorisv1alpha1.RoleSpec{
+				RoleGroups: map[string]dorisv1alpha1.RoleGroupSpec{
+					"default": {Replicas: &desired},
+				},
+			},
+		},
+	}
+
+	// Simulate gating: copy the roleGroup, modify replicas, put back
+	rg := instance.Spec.Backend.RoleGroups["default"]
+	original := rg.Replicas
+	rg.Replicas = &current
+	instance.Spec.Backend.RoleGroups["default"] = rg
+
+	if *instance.Spec.Backend.RoleGroups["default"].Replicas != current {
+		t.Errorf("expected gated replicas %d, got %d", current, *instance.Spec.Backend.RoleGroups["default"].Replicas)
+	}
+
+	// Restore
+	rg = instance.Spec.Backend.RoleGroups["default"]
+	rg.Replicas = original
+	instance.Spec.Backend.RoleGroups["default"] = rg
+
+	if *instance.Spec.Backend.RoleGroups["default"].Replicas != desired {
+		t.Errorf("expected restored replicas %d, got %d", desired, *instance.Spec.Backend.RoleGroups["default"].Replicas)
+	}
+}
+
+func TestGateBESpecReplicas_MultiRoleGroup(t *testing.T) {
+	rg1Desired := int32(2)
+	rg2Desired := int32(1)
+	totalDesired := rg1Desired + rg2Desired
+	currentReplicas := int32(6) // 2 roleGroups want 3 total, but 6 running
+
+	instance := &dorisv1alpha1.DorisCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"doris.kubedoop.dev/decommission-start/be-2": "2026-05-19T10:00:00Z",
+			},
+		},
+		Spec: dorisv1alpha1.DorisClusterSpec{
+			Backend: &dorisv1alpha1.RoleSpec{
+				RoleGroups: map[string]dorisv1alpha1.RoleGroupSpec{
+					"rg1": {Replicas: &rg1Desired},
+					"rg2": {Replicas: &rg2Desired},
+				},
+			},
+		},
+	}
+
+	// Simulate proportional gating
+	originals := make(map[string]int32)
+	remaining := currentReplicas
+	groupNames := []string{"rg1", "rg2"}
+
+	for i, name := range groupNames {
+		rg := instance.Spec.Backend.RoleGroups[name]
+		original := int32(0)
+		if rg.Replicas != nil {
+			original = *rg.Replicas
+		}
+		originals[name] = original
+
+		groupDesired := original
+		var gated int32
+		if i == len(groupNames)-1 {
+			gated = remaining
+		} else {
+			gated = currentReplicas * groupDesired / totalDesired
+			if gated < 1 {
+				gated = 1
+			}
+		}
+		remaining -= gated
+		rg.Replicas = &gated
+		instance.Spec.Backend.RoleGroups[name] = rg
+	}
+
+	// Verify total gated replicas equals current
+	totalGated := int32(0)
+	for _, rg := range instance.Spec.Backend.RoleGroups {
+		if rg.Replicas != nil {
+			totalGated += *rg.Replicas
+		}
+	}
+	if totalGated != currentReplicas {
+		t.Errorf("total gated replicas = %d, want %d", totalGated, currentReplicas)
+	}
+
+	// Restore
+	for name, original := range originals {
+		rg := instance.Spec.Backend.RoleGroups[name]
+		rg.Replicas = &original
+		instance.Spec.Backend.RoleGroups[name] = rg
+	}
+
+	if *instance.Spec.Backend.RoleGroups["rg1"].Replicas != rg1Desired {
+		t.Errorf("rg1 restored = %d, want %d", *instance.Spec.Backend.RoleGroups["rg1"].Replicas, rg1Desired)
+	}
+	if *instance.Spec.Backend.RoleGroups["rg2"].Replicas != rg2Desired {
+		t.Errorf("rg2 restored = %d, want %d", *instance.Spec.Backend.RoleGroups["rg2"].Replicas, rg2Desired)
+	}
+}
+
+func TestScaleDownPolicy_Timeout(t *testing.T) {
+	spec := &dorisv1alpha1.DorisClusterSpec{}
+	policy := &clusterScaleDownPolicy{spec: spec}
+
+	timeout := policy.GetDecommissionTimeout()
+	if timeout != 2*1000000000*3600 { // 2h in nanoseconds
+		t.Errorf("expected 2h default timeout, got %v", timeout)
+	}
+
+	// Custom timeout
+	custom := metav1.Duration{Duration: 30 * 60 * 1000000000} // 30 minutes
+	spec.ClusterConfig = &dorisv1alpha1.ClusterConfigSpec{
+		ScaleDownPolicy: &dorisv1alpha1.ScaleDownPolicySpec{
+			DecommissionTimeout: &custom,
+		},
+	}
+	timeout = policy.GetDecommissionTimeout()
+	if timeout != 30*60*1000000000 {
+		t.Errorf("expected 30m custom timeout, got %v", timeout)
+	}
+}
+
+// Ensure the core types satisfy interfaces at compile time
+var (
+	_ scale.ScaleDownPolicy     = (*clusterScaleDownPolicy)(nil)
+	_ scale.DecommissionTracker = (*decommissionTracker)(nil)
+)

--- a/internal/controller/doriscluster_controller_test.go
+++ b/internal/controller/doriscluster_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"sort"
 	"testing"
 	"time"
 
@@ -60,6 +61,26 @@ func TestDecommissionTracker_GetStart(t *testing.T) {
 	_, ok = tracker.GetStart("be-0")
 	if ok {
 		t.Error("expected false after clear")
+	}
+}
+
+// assertPendingPodsSet compares PendingPods() result against want as a set.
+func assertPendingPodsSet(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf("PendingPods() len = %d, want %d", len(got), len(want))
+		return
+	}
+	gotSorted := make([]string, len(got))
+	copy(gotSorted, got)
+	sort.Strings(gotSorted)
+	wantSorted := make([]string, len(want))
+	copy(wantSorted, want)
+	sort.Strings(wantSorted)
+	for i := range gotSorted {
+		if gotSorted[i] != wantSorted[i] {
+			t.Errorf("PendingPods()[%d] = %q, want %q", i, gotSorted[i], wantSorted[i])
+		}
 	}
 }
 
@@ -127,16 +148,7 @@ func TestDecommissionTracker_PendingPods(t *testing.T) {
 			if tt.pending != nil {
 				tracker.pending = tt.pending
 			}
-			got := tracker.PendingPods()
-			if len(got) != len(tt.want) {
-				t.Errorf("PendingPods() len = %d, want %d", len(got), len(tt.want))
-				return
-			}
-			for i := range got {
-				if got[i] != tt.want[i] {
-					t.Errorf("PendingPods()[%d] = %q, want %q", i, got[i], tt.want[i])
-				}
-			}
+			assertPendingPodsSet(t, tracker.PendingPods(), tt.want)
 		})
 	}
 }
@@ -189,14 +201,16 @@ func TestGateBESpecReplicas_SingleRoleGroup(t *testing.T) {
 	// Simulate gating: copy the roleGroup, modify replicas, put back
 	rg := instance.Spec.Backend.RoleGroups["default"]
 	original := rg.Replicas
-	rg.Replicas = &current
+
+	gated := current // stable allocation, not a loop variable
+	rg.Replicas = &gated
 	instance.Spec.Backend.RoleGroups["default"] = rg
 
 	if *instance.Spec.Backend.RoleGroups["default"].Replicas != current {
 		t.Errorf("expected gated replicas %d, got %d", current, *instance.Spec.Backend.RoleGroups["default"].Replicas)
 	}
 
-	// Restore
+	// Restore — re-read from map, modify, write back
 	rg = instance.Spec.Backend.RoleGroups["default"]
 	rg.Replicas = original
 	instance.Spec.Backend.RoleGroups["default"] = rg
@@ -230,7 +244,7 @@ func TestGateBESpecReplicas_MultiRoleGroup(t *testing.T) {
 		},
 	}
 
-	// Simulate proportional gating
+	// Simulate proportional gating with stable per-group allocations
 	originals := make(map[string]int32)
 	remaining := currentReplicas
 	groupNames := []string{"rg1", "rg2"}
@@ -254,7 +268,10 @@ func TestGateBESpecReplicas_MultiRoleGroup(t *testing.T) {
 			}
 		}
 		remaining -= gated
-		rg.Replicas = &gated
+
+		// Stable per-group allocation — copy to a new variable before taking address
+		gatedCopy := gated
+		rg.Replicas = &gatedCopy
 		instance.Spec.Backend.RoleGroups[name] = rg
 	}
 
@@ -269,18 +286,21 @@ func TestGateBESpecReplicas_MultiRoleGroup(t *testing.T) {
 		t.Errorf("total gated replicas = %d, want %d", totalGated, currentReplicas)
 	}
 
-	// Restore
+	// Restore using stable originals
 	for name, original := range originals {
 		rg := instance.Spec.Backend.RoleGroups[name]
 		rg.Replicas = &original
 		instance.Spec.Backend.RoleGroups[name] = rg
 	}
 
-	if *instance.Spec.Backend.RoleGroups["rg1"].Replicas != rg1Desired {
-		t.Errorf("rg1 restored = %d, want %d", *instance.Spec.Backend.RoleGroups["rg1"].Replicas, rg1Desired)
+	// Verify restoration by value (not pointer identity)
+	rg1 := instance.Spec.Backend.RoleGroups["rg1"]
+	if rg1.Replicas == nil || *rg1.Replicas != rg1Desired {
+		t.Errorf("rg1 restored = %v, want %d", rg1.Replicas, rg1Desired)
 	}
-	if *instance.Spec.Backend.RoleGroups["rg2"].Replicas != rg2Desired {
-		t.Errorf("rg2 restored = %d, want %d", *instance.Spec.Backend.RoleGroups["rg2"].Replicas, rg2Desired)
+	rg2 := instance.Spec.Backend.RoleGroups["rg2"]
+	if rg2.Replicas == nil || *rg2.Replicas != rg2Desired {
+		t.Errorf("rg2 restored = %v, want %d", rg2.Replicas, rg2Desired)
 	}
 }
 

--- a/internal/controller/scale/be.go
+++ b/internal/controller/scale/be.go
@@ -23,9 +23,9 @@ func NewBEScaleManager(client *doris_client.DorisClient) *BEScaleManager {
 
 // ScaleDown performs scale-down for BE nodes.
 // It returns the list of pods that have been decommissioned (ready for removal).
-// When scaleConfig is non-nil, decommission timeout is enforced: if decommission exceeds
+// When policy is non-nil, decommission timeout is enforced: if decommission exceeds
 // the configured timeout, the strategy automatically falls back to force-drop.
-func (m *BEScaleManager) ScaleDown(ctx context.Context, action ScaleAction, scaleConfig ScaleConfig) ([]string, error) {
+func (m *BEScaleManager) ScaleDown(ctx context.Context, action ScaleAction, policy ScaleDownPolicy, tracker DecommissionTracker) ([]string, error) {
 	if !action.IsScaleDown() {
 		return nil, nil
 	}
@@ -41,8 +41,8 @@ func (m *BEScaleManager) ScaleDown(ctx context.Context, action ScaleAction, scal
 
 	var readyForRemoval []string
 	var decommissionTimeout time.Duration
-	if scaleConfig != nil {
-		decommissionTimeout = scaleConfig.GetDecommissionTimeout()
+	if policy != nil {
+		decommissionTimeout = policy.GetDecommissionTimeout()
 	}
 
 	for _, podName := range action.PodsToRemove {
@@ -51,6 +51,9 @@ func (m *BEScaleManager) ScaleDown(ctx context.Context, action ScaleAction, scal
 			beScaleLogger.Info("BE node not found in Doris cluster, safe to remove",
 				"pod", podName)
 			readyForRemoval = append(readyForRemoval, podName)
+			if tracker != nil {
+				tracker.ClearStart(podName)
+			}
 			continue
 		}
 
@@ -61,10 +64,13 @@ func (m *BEScaleManager) ScaleDown(ctx context.Context, action ScaleAction, scal
 					beScaleLogger.Info("BE decommission complete, ready for removal",
 						"pod", podName, "host", be.Host)
 					readyForRemoval = append(readyForRemoval, podName)
+					if tracker != nil {
+						tracker.ClearStart(podName)
+					}
 				} else {
 					// Check decommission timeout for fallback to force-drop
-					if decommissionTimeout > 0 && scaleConfig != nil {
-						if startAnno, ok := scaleConfig.GetDecommissionStartAnnotation(podName); ok {
+					if decommissionTimeout > 0 && tracker != nil {
+						if startAnno, ok := tracker.GetStart(podName); ok {
 							if startedAt, err := time.Parse(time.RFC3339, startAnno); err == nil {
 								elapsed := time.Since(startedAt)
 								if elapsed > decommissionTimeout {
@@ -76,6 +82,7 @@ func (m *BEScaleManager) ScaleDown(ctx context.Context, action ScaleAction, scal
 										return nil, fmt.Errorf("failed to force-drop timed-out BE %s: %w", podName, dropErr)
 									}
 									readyForRemoval = append(readyForRemoval, podName)
+									tracker.ClearStart(podName)
 									continue
 								}
 							}
@@ -92,8 +99,8 @@ func (m *BEScaleManager) ScaleDown(ctx context.Context, action ScaleAction, scal
 					return nil, fmt.Errorf("failed to decommission BE %s: %w", podName, err)
 				}
 				// Record decommission start time for timeout tracking
-				if scaleConfig != nil && decommissionTimeout > 0 {
-					scaleConfig.SetDecommissionStartAnnotation(podName, time.Now().UTC().Format(time.RFC3339))
+				if tracker != nil && decommissionTimeout > 0 {
+					tracker.RecordStart(podName, time.Now().UTC().Format(time.RFC3339))
 				}
 			}
 

--- a/internal/controller/scale/be.go
+++ b/internal/controller/scale/be.go
@@ -85,7 +85,19 @@ func (m *BEScaleManager) ScaleDown(ctx context.Context, action ScaleAction, poli
 									tracker.ClearStart(podName)
 									continue
 								}
+							} else {
+								// Invalid timestamp — clear and backfill
+								beScaleLogger.Info("Invalid decommission start timestamp, backfilling",
+									"pod", podName, "value", startAnno)
+								tracker.ClearStart(podName)
+								tracker.RecordStart(podName, time.Now().UTC().Format(time.RFC3339))
 							}
+						} else {
+							// Backfill: decommission in progress but start time missing
+							// (controller restart, upgrade with existing decommissions).
+							beScaleLogger.Info("Backfilling missing decommission start time",
+								"pod", podName)
+							tracker.RecordStart(podName, time.Now().UTC().Format(time.RFC3339))
 						}
 					}
 					beScaleLogger.Info("BE decommission in progress, waiting",

--- a/internal/controller/scale/be.go
+++ b/internal/controller/scale/be.go
@@ -3,6 +3,7 @@ package scale
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/zncdatadev/doris-operator/internal/controller/doris_client"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -20,9 +21,11 @@ func NewBEScaleManager(client *doris_client.DorisClient) *BEScaleManager {
 	return &BEScaleManager{client: client}
 }
 
-// ScaleDown performs scale-down for BE nodes
-// It returns the number of pods that have been decommissioned (ready for removal).
-func (m *BEScaleManager) ScaleDown(ctx context.Context, action ScaleAction) ([]string, error) {
+// ScaleDown performs scale-down for BE nodes.
+// It returns the list of pods that have been decommissioned (ready for removal).
+// When scaleConfig is non-nil, decommission timeout is enforced: if decommission exceeds
+// the configured timeout, the strategy automatically falls back to force-drop.
+func (m *BEScaleManager) ScaleDown(ctx context.Context, action ScaleAction, scaleConfig ScaleConfig) ([]string, error) {
 	if !action.IsScaleDown() {
 		return nil, nil
 	}
@@ -37,6 +40,10 @@ func (m *BEScaleManager) ScaleDown(ctx context.Context, action ScaleAction) ([]s
 	}
 
 	var readyForRemoval []string
+	var decommissionTimeout time.Duration
+	if scaleConfig != nil {
+		decommissionTimeout = scaleConfig.GetDecommissionTimeout()
+	}
 
 	for _, podName := range action.PodsToRemove {
 		be := doris_client.MatchPodToBackend(podName, backends)
@@ -55,15 +62,38 @@ func (m *BEScaleManager) ScaleDown(ctx context.Context, action ScaleAction) ([]s
 						"pod", podName, "host", be.Host)
 					readyForRemoval = append(readyForRemoval, podName)
 				} else {
+					// Check decommission timeout for fallback to force-drop
+					if decommissionTimeout > 0 && scaleConfig != nil {
+						if startAnno, ok := scaleConfig.GetDecommissionStartAnnotation(podName); ok {
+							if startedAt, err := time.Parse(time.RFC3339, startAnno); err == nil {
+								elapsed := time.Since(startedAt)
+								if elapsed > decommissionTimeout {
+									beScaleLogger.Info("BE decommission timed out, force-dropping",
+										"pod", podName, "host", be.Host,
+										"elapsed", elapsed.Round(time.Second),
+										"timeout", decommissionTimeout)
+									if dropErr := m.client.DropBackend(ctx, be.Host, be.Port); dropErr != nil {
+										return nil, fmt.Errorf("failed to force-drop timed-out BE %s: %w", podName, dropErr)
+									}
+									readyForRemoval = append(readyForRemoval, podName)
+									continue
+								}
+							}
+						}
+					}
 					beScaleLogger.Info("BE decommission in progress, waiting",
 						"pod", podName, "host", be.Host, "tabletNum", be.TabletNum)
 				}
 			} else {
-				// Start decommission
+				// Start decommission and record start time
 				beScaleLogger.Info("Starting BE decommission",
 					"pod", podName, "host", be.Host, "port", be.Port)
 				if err := m.client.DecommissionBackend(ctx, be.Host, be.Port); err != nil {
 					return nil, fmt.Errorf("failed to decommission BE %s: %w", podName, err)
+				}
+				// Record decommission start time for timeout tracking
+				if scaleConfig != nil && decommissionTimeout > 0 {
+					scaleConfig.SetDecommissionStartAnnotation(podName, time.Now().UTC().Format(time.RFC3339))
 				}
 			}
 

--- a/internal/controller/scale/config.go
+++ b/internal/controller/scale/config.go
@@ -1,19 +1,31 @@
 package scale
 
 import (
+	"context"
 	"time"
 )
 
-// ScaleConfig provides scale-down configuration for the scale manager.
-type ScaleConfig interface {
+// ScaleDownPolicy provides read-only scale-down configuration.
+type ScaleDownPolicy interface {
 	// GetDecommissionTimeout returns the maximum duration to wait for BE decommission.
 	// After this timeout, the operator will force-drop the node.
 	GetDecommissionTimeout() time.Duration
-	// GetDecommissionStartAnnotation returns the recorded decommission start time
-	// for a given pod name, and whether it exists.
-	GetDecommissionStartAnnotation(podName string) (string, bool)
-	// SetDecommissionStartAnnotation records the decommission start time for a pod.
-	SetDecommissionStartAnnotation(podName string, timestamp string)
-	// PersistAnnotations persists any pending annotation changes.
-	PersistAnnotations() error
+}
+
+// DecommissionTracker manages BE decommission lifecycle state.
+// It tracks start times and handles persistence of annotation updates.
+type DecommissionTracker interface {
+	// GetStart returns the decommission start time for a pod (RFC3339).
+	// Returns the timestamp and true if set, empty string and false otherwise.
+	GetStart(podName string) (string, bool)
+	// RecordStart records the decommission start time for a pod.
+	RecordStart(podName string, timestamp string)
+	// ClearStart removes the decommission start time for a pod.
+	ClearStart(podName string)
+	// Persist writes all pending changes (records + clears) to the backing store.
+	// Must be called after RecordStart/ClearStart to take effect.
+	Persist(ctx context.Context) error
+	// PendingPods returns pod names that have active (non-cleared) decommission tracking.
+	// Used to determine if any STS replicas need to be gated.
+	PendingPods() []string
 }

--- a/internal/controller/scale/config.go
+++ b/internal/controller/scale/config.go
@@ -1,0 +1,19 @@
+package scale
+
+import (
+	"time"
+)
+
+// ScaleConfig provides scale-down configuration for the scale manager.
+type ScaleConfig interface {
+	// GetDecommissionTimeout returns the maximum duration to wait for BE decommission.
+	// After this timeout, the operator will force-drop the node.
+	GetDecommissionTimeout() time.Duration
+	// GetDecommissionStartAnnotation returns the recorded decommission start time
+	// for a given pod name, and whether it exists.
+	GetDecommissionStartAnnotation(podName string) (string, bool)
+	// SetDecommissionStartAnnotation records the decommission start time for a pod.
+	SetDecommissionStartAnnotation(podName string, timestamp string)
+	// PersistAnnotations persists any pending annotation changes.
+	PersistAnnotations() error
+}

--- a/internal/controller/scale/manager.go
+++ b/internal/controller/scale/manager.go
@@ -45,6 +45,11 @@ type ScaleResult struct {
 	FEStatuses []FENodeStatus
 	// BrokerStatuses contains current Broker node statuses
 	BrokerStatuses []BrokerNodeStatus
+	// GatedReplicas maps STS names to their minimum replica count.
+	// When a component has an in-progress scale-down (e.g., BE decommission not yet complete),
+	// the corresponding STS replicas are gated to prevent premature pod deletion.
+	// The controller should patch these STS to the gated replica count after reconciliation.
+	GatedReplicas map[string]int32
 }
 
 // ReconcileScale performs scale reconciliation for all components.
@@ -54,9 +59,11 @@ func (m *ScaleManager) ReconcileScale(
 	ctx context.Context,
 	spec *dorisv1alpha1.DorisClusterSpec,
 	replicaStates map[constants.ComponentType]*ReplicaState,
+	scaleConfig ScaleConfig,
 ) (*ScaleResult, error) {
 	result := &ScaleResult{
 		CompletedRemovals: make(map[constants.ComponentType][]string),
+		GatedReplicas:     make(map[string]int32),
 	}
 
 	// Compute and execute scale actions
@@ -77,7 +84,7 @@ func (m *ScaleManager) ReconcileScale(
 			if action.IsScaleDown() {
 				switch action.Component {
 				case constants.ComponentTypeBE:
-					beResult, err := m.beManager.ScaleDown(ctx, action)
+					beResult, err := m.beManager.ScaleDown(ctx, action, scaleConfig)
 					if err != nil {
 						return nil, fmt.Errorf("BE scale-down failed: %w", err)
 					}
@@ -88,6 +95,13 @@ func (m *ScaleManager) ReconcileScale(
 					if len(beResult) < len(action.PodsToRemove) {
 						result.NeedRequeue = true
 						result.RequeueAfter = 30 * time.Second
+						// Gate: prevent STS from scaling down until decommission completes.
+						// Set gated replicas to the current count so pods are not deleted prematurely.
+						if state, ok := replicaStates[constants.ComponentTypeBE]; ok {
+							for _, stsName := range action.StSNames {
+								result.GatedReplicas[stsName] = state.CurrentReplicas
+							}
+						}
 					}
 
 				case constants.ComponentTypeFE:

--- a/internal/controller/scale/manager.go
+++ b/internal/controller/scale/manager.go
@@ -37,19 +37,12 @@ type ScaleResult struct {
 	NeedRequeue bool
 	// RequeueAfter is the duration to wait before requeuing
 	RequeueAfter time.Duration
-	// CompletedRemovals lists pods that are ready for StatefulSet scale-down
-	CompletedRemovals map[constants.ComponentType][]string
 	// BEStatuses contains current BE node statuses
 	BEStatuses []BENodeStatus
 	// FEStatuses contains current FE node statuses
 	FEStatuses []FENodeStatus
 	// BrokerStatuses contains current Broker node statuses
 	BrokerStatuses []BrokerNodeStatus
-	// GatedReplicas maps STS names to their minimum replica count.
-	// When a component has an in-progress scale-down (e.g., BE decommission not yet complete),
-	// the corresponding STS replicas are gated to prevent premature pod deletion.
-	// The controller should patch these STS to the gated replica count after reconciliation.
-	GatedReplicas map[string]int32
 }
 
 // ReconcileScale performs scale reconciliation for all components.
@@ -59,12 +52,10 @@ func (m *ScaleManager) ReconcileScale(
 	ctx context.Context,
 	spec *dorisv1alpha1.DorisClusterSpec,
 	replicaStates map[constants.ComponentType]*ReplicaState,
-	scaleConfig ScaleConfig,
+	policy ScaleDownPolicy,
+	tracker DecommissionTracker,
 ) (*ScaleResult, error) {
-	result := &ScaleResult{
-		CompletedRemovals: make(map[constants.ComponentType][]string),
-		GatedReplicas:     make(map[string]int32),
-	}
+	result := &ScaleResult{}
 
 	// Compute and execute scale actions
 	actions := ComputeScaleActions(spec, replicaStates)
@@ -84,24 +75,14 @@ func (m *ScaleManager) ReconcileScale(
 			if action.IsScaleDown() {
 				switch action.Component {
 				case constants.ComponentTypeBE:
-					beResult, err := m.beManager.ScaleDown(ctx, action, scaleConfig)
+					beResult, err := m.beManager.ScaleDown(ctx, action, policy, tracker)
 					if err != nil {
 						return nil, fmt.Errorf("BE scale-down failed: %w", err)
-					}
-					if len(beResult) > 0 {
-						result.CompletedRemovals[constants.ComponentTypeBE] = beResult
 					}
 					// Requeue if not all pods are ready for removal
 					if len(beResult) < len(action.PodsToRemove) {
 						result.NeedRequeue = true
 						result.RequeueAfter = 30 * time.Second
-						// Gate: prevent STS from scaling down until decommission completes.
-						// Set gated replicas to the current count so pods are not deleted prematurely.
-						if state, ok := replicaStates[constants.ComponentTypeBE]; ok {
-							for _, stsName := range action.StSNames {
-								result.GatedReplicas[stsName] = state.CurrentReplicas
-							}
-						}
 					}
 
 				case constants.ComponentTypeFE:
@@ -109,8 +90,9 @@ func (m *ScaleManager) ReconcileScale(
 					if err != nil {
 						return nil, fmt.Errorf("FE scale-down failed: %w", err)
 					}
-					if len(feResult) > 0 {
-						result.CompletedRemovals[constants.ComponentTypeFE] = feResult
+					if len(feResult) < len(action.PodsToRemove) {
+						result.NeedRequeue = true
+						result.RequeueAfter = 30 * time.Second
 					}
 
 				default:

--- a/internal/controller/scale/replicas.go
+++ b/internal/controller/scale/replicas.go
@@ -21,9 +21,9 @@ const (
 	// StrategyDropObserver is the default FE scale-down strategy
 	StrategyDropObserver = "drop-observer"
 
-	// AnnotationDecommissionStart is the annotation key on the DorisCluster CR
-	// that records when BE decommission started (RFC3339 timestamp).
-	// Format: "sts-name:timestamp,sts-name:timestamp"
+	// AnnotationDecommissionStart is the annotation key prefix on the DorisCluster CR
+	// used to track BE decommission start times. Each pod gets its own annotation:
+	//   doris.kubedoop.dev/decommission-start/<pod-name> = <RFC3339 timestamp>
 	AnnotationDecommissionStart = "doris.kubedoop.dev/decommission-start"
 )
 
@@ -39,9 +39,9 @@ type ScaleAction struct {
 	PodsToRemove []string
 	// Strategy is the scale-down strategy for this component
 	Strategy string
-	// StSNames lists the StatefulSet names involved in this scale action.
+	// StatefulSetNames lists the StatefulSet names involved in this scale action.
 	// Used for STS replica gating during decommission.
-	StSNames []string
+	StatefulSetNames []string
 }
 
 // IsScaleDown returns true if this is a scale-down action
@@ -66,8 +66,8 @@ type ReplicaState struct {
 	ReadyReplicas int32
 	// Pod names currently running (sorted by ordinal)
 	PodNames []string
-	// StSNames lists the StatefulSet names for this component.
-	StSNames []string
+	// StatefulSetNames lists the StatefulSet names for this component.
+	StatefulSetNames []string
 }
 
 // GetEffectiveReplicas resolves the effective replica count for a component.
@@ -121,11 +121,11 @@ func ComputeScaleActions(
 		desired := GetEffectiveReplicas(comp.roleSpec)
 
 		action := ScaleAction{
-			Component:       comp.ct,
-			CurrentReplicas: state.CurrentReplicas,
-			DesiredReplicas: desired,
-			Strategy:        comp.strategy,
-			StSNames:        state.StSNames,
+			Component:        comp.ct,
+			CurrentReplicas:  state.CurrentReplicas,
+			DesiredReplicas:  desired,
+			Strategy:         comp.strategy,
+			StatefulSetNames: state.StatefulSetNames,
 		}
 
 		if action.IsScaleDown() {

--- a/internal/controller/scale/replicas.go
+++ b/internal/controller/scale/replicas.go
@@ -2,6 +2,7 @@ package scale
 
 import (
 	"fmt"
+	"time"
 
 	dorisv1alpha1 "github.com/zncdatadev/doris-operator/api/v1alpha1"
 	"github.com/zncdatadev/doris-operator/internal/controller/constants"
@@ -11,7 +12,7 @@ import (
 
 const (
 	// defaultDecommissionTimeout is the default timeout for BE decommission
-	defaultDecommissionTimeout = "2h"
+	defaultDecommissionTimeout = 2 * time.Hour
 
 	// StrategyDecommission is the default BE scale-down strategy
 	StrategyDecommission = "decommission"
@@ -19,6 +20,11 @@ const (
 	StrategyForceDrop = "force-drop"
 	// StrategyDropObserver is the default FE scale-down strategy
 	StrategyDropObserver = "drop-observer"
+
+	// AnnotationDecommissionStart is the annotation key on the DorisCluster CR
+	// that records when BE decommission started (RFC3339 timestamp).
+	// Format: "sts-name:timestamp,sts-name:timestamp"
+	AnnotationDecommissionStart = "doris.kubedoop.dev/decommission-start"
 )
 
 // ScaleAction represents a scale operation to perform
@@ -33,6 +39,9 @@ type ScaleAction struct {
 	PodsToRemove []string
 	// Strategy is the scale-down strategy for this component
 	Strategy string
+	// StSNames lists the StatefulSet names involved in this scale action.
+	// Used for STS replica gating during decommission.
+	StSNames []string
 }
 
 // IsScaleDown returns true if this is a scale-down action
@@ -49,7 +58,7 @@ func (a *ScaleAction) IsScaleUp() bool {
 type ReplicaState struct {
 	// Component type
 	Component constants.ComponentType
-	// DesiredReplicas from StatefulSet spec (what the STS is targeting)
+	// SpecReplicas from StatefulSet spec (what the STS is targeting)
 	SpecReplicas int32
 	// CurrentReplicas from StatefulSet status (actual number of pods currently running)
 	CurrentReplicas int32
@@ -57,6 +66,8 @@ type ReplicaState struct {
 	ReadyReplicas int32
 	// Pod names currently running (sorted by ordinal)
 	PodNames []string
+	// StSNames lists the StatefulSet names for this component.
+	StSNames []string
 }
 
 // GetEffectiveReplicas resolves the effective replica count for a component.
@@ -114,6 +125,7 @@ func ComputeScaleActions(
 			CurrentReplicas: state.CurrentReplicas,
 			DesiredReplicas: desired,
 			Strategy:        comp.strategy,
+			StSNames:        state.StSNames,
 		}
 
 		if action.IsScaleDown() {
@@ -167,11 +179,10 @@ func getFEStrategy(spec *dorisv1alpha1.DorisClusterSpec) string {
 }
 
 // GetDecommissionTimeout returns the decommission timeout duration.
-// TODO: Implement timeout tracking in BE scale-down to automatically fallback to force-drop.
-func GetDecommissionTimeout(spec *dorisv1alpha1.DorisClusterSpec) string {
+func GetDecommissionTimeout(spec *dorisv1alpha1.DorisClusterSpec) time.Duration {
 	if spec.ClusterConfig != nil && spec.ClusterConfig.ScaleDownPolicy != nil &&
 		spec.ClusterConfig.ScaleDownPolicy.DecommissionTimeout != nil {
-		return spec.ClusterConfig.ScaleDownPolicy.DecommissionTimeout.Duration.String()
+		return spec.ClusterConfig.ScaleDownPolicy.DecommissionTimeout.Duration
 	}
 	return defaultDecommissionTimeout
 }


### PR DESCRIPTION
## Summary

Implements two key safety improvements for BE scale-down operations:

### 1. StatefulSet Replica Gating
- When BE decommission is in progress, the controller now **gates STS replicas** to prevent operator-go's STS reconciler from prematurely deleting pods
- After scale manager detects incomplete decommission, it patches STS replicas back to the current count
- Decommission completes → gate is lifted → STS scales down naturally

### 2. Decommission Timeout with Auto Force-Drop
- Configurable `decommissionTimeout` in `spec.clusterConfig.scaleDownPolicy` (default: 2h)
- Decommission start time is tracked via CR annotations (`doris.kubedoop.dev/decommission-start/<pod>`)
- When timeout is exceeded, the strategy automatically falls back to **force-drop** to prevent stuck scale-down
- Annotations are cleaned up when pods are removed

### Changes
| File | Description |
|------|-------------|
| `internal/controller/scale/config.go` | New `ScaleConfig` interface for timeout tracking |
| `internal/controller/scale/be.go` | Timeout enforcement + annotation recording in `ScaleDown()` |
| `internal/controller/scale/manager.go` | Pass ScaleConfig to BE manager, return `GatedReplicas` in result |
| `internal/controller/scale/replicas.go` | Export `GetDecommissionTimeout()` |
| `internal/controller/doriscluster_controller.go` | `clusterScaleConfig` implementation, `gateSTSReplicas()`, annotation persistence |
| `AGENTS.md` | Updated documentation |

### Resolves
Eliminates the TODO: "Gate StatefulSet replica decrease behind scale manager"