### PR TITLE
chore: bump Go from 1.25.3 to 1.25.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM quay.io/zncdatadev/go-devel:1.25.5-kubedoop0.0.0-dev AS builder
+FROM quay.io/zncdatadev/go-devel:1.25.8-kubedoop0.0.0-dev AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG LDFLAGS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zncdatadev/doris-operator
 
-go 1.25.3
+go 1.25.8
 
 require (
 	emperror.dev/errors v0.8.1


### PR DESCRIPTION
## Summary
Bump Go version to align with baseline requirement.

## Changes
- go.mod: go 1.25.3 → 1.25.8
- Dockerfile: go-devel:1.25.5 → go-devel:1.25.8

## Testing
- [ ] CI checks pass