### PR TITLE
chore: add Helm Chart scaffolding for release pipeline

### DIFF
--- a/.github/configs/ct-install.yaml
+++ b/.github/configs/ct-install.yaml
@@ -1,0 +1,13 @@
+## Reference: https://github.com/helm/chart-testing/blob/master/doc/ct_lint-and-install.md
+# Don't add the 'debug' attribute, otherwise the workflow won't work anymore
+# Only Used for the CT Install Stage
+
+chart-dirs:
+  - deploy/helm
+chart-repos: []
+helm-extra-args: "--timeout 600s"
+validate-chart-schema: false
+validate-maintainers: false
+validate-yaml: true
+exclude-deprecated: true
+excluded-charts: []

--- a/.github/configs/ct-lint.yaml
+++ b/.github/configs/ct-lint.yaml
@@ -1,0 +1,12 @@
+## Reference: https://github.com/helm/chart-testing/blob/main/doc/ct_lint.md
+# Don't add the 'debug' attribute, otherwise the workflow won't work anymore
+# Only Used for the CT Lint Stage
+chart-dirs:
+  - deploy/helm
+chart-repos: []
+validate-chart-schema: false
+validate-maintainers: false
+validate-yaml: true
+exclude-deprecated: true
+check-version-increment: false
+excluded-charts: []

--- a/Makefile
+++ b/Makefile
@@ -258,6 +258,24 @@ ifneq ($(strip $(HELM_DEPENDS)),)
 	done
 endif
 
+##@ Helm Chart
+
+OCI_REGISTRY ?= oci://quay.io/kubedoopcharts
+
+.PHONY: helm-crd-sync ## Sync CRDs to helm chart for the operator.
+helm-crd-sync: manifests ## Sync CRDs to helm chart for the operator
+	cp config/crd/bases/doris.kubedoop.dev_dorisclusters.yaml deploy/helm/$(PROJECT_NAME)/crds/crds.yaml
+
+.PHONY: helm-chart-package ## Package helm chart for the operator.
+helm-chart-package: ## Package helm chart for the operator.
+	mkdir -p target/charts
+	rm -rf target/charts/*.tgz
+	"$(HELM)" package deploy/helm/$(PROJECT_NAME) --version $(VERSION) --app-version $(VERSION) --destination target/charts
+
+.PHONY: helm-chart-publish ## Publish helm chart for the operator.
+helm-chart-publish: helm-chart-package ## Publish helm chart for the operator.
+	"$(HELM)" push target/charts/$(PROJECT_NAME)-$(VERSION).tgz $(OCI_REGISTRY)
+
 ##@ Chainsaw-E2E
 
 # Tool Versions

--- a/deploy/helm/doris-operator/Chart.yaml
+++ b/deploy/helm/doris-operator/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: doris-operator
+description: Apache Doris operator of Kubedoop
+
+type: application
+
+version: 0.0.0-dev
+appVersion: 0.0.0-dev
+
+maintainers:
+  - email: zncdatadev@googlegroups.com
+    name: ZNCDataDev Team

--- a/deploy/helm/doris-operator/crds/crds.yaml
+++ b/deploy/helm/doris-operator/crds/crds.yaml
@@ -1,0 +1,1293 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: dorisclusters.doris.kubedoop.dev
+spec:
+  group: doris.kubedoop.dev
+  names:
+    kind: DorisCluster
+    listKind: DorisClusterList
+    plural: dorisclusters
+    singular: doriscluster
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DorisCluster is the Schema for the dorisclusters API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DorisClusterSpec defines the desired state of DorisCluster
+            properties:
+              authSecret:
+                description: |-
+                  AuthSecret references a Secret containing the Doris cluster admin credentials.
+                  The Secret must be of type `kubernetes.io/basic-auth` with keys `username` and `password`.
+                  If configured, the operator will use these credentials to connect to Doris FE for scale management.
+                  If the specified user does not exist in Doris, the operator will create it with NODE_PRIV
+                  and GRANT_PRIV privileges on first cluster initialization.
+                  If not configured, the operator defaults to root with an empty password.
+                properties:
+                  secretName:
+                    description: |-
+                      Name of the Secret in the same namespace as the DorisCluster.
+                      The Secret should be of type `kubernetes.io/basic-auth` with keys:
+                        - username: the admin user name (defaults to "root" if not set)
+                        - password: the admin user password
+                    type: string
+                required:
+                - secretName
+                type: object
+              backend:
+                properties:
+                  cliOverrides:
+                    items:
+                      type: string
+                    type: array
+                  config:
+                    properties:
+                      affinity:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      gracefulShutdownTimeout:
+                        default: 30s
+                        type: string
+                      logging:
+                        properties:
+                          containers:
+                            additionalProperties:
+                              properties:
+                                console:
+                                  description: |-
+                                    LogLevelSpec
+                                    level mapping if app log level is not standard
+                                      - FATAL -> CRITICAL
+                                      - ERROR -> ERROR
+                                      - WARN -> WARNING
+                                      - INFO -> INFO
+                                      - DEBUG -> DEBUG
+                                      - TRACE -> DEBUG
+
+                                    Default log level is INFO
+                                  properties:
+                                    level:
+                                      default: INFO
+                                      enum:
+                                      - FATAL
+                                      - ERROR
+                                      - WARN
+                                      - INFO
+                                      - DEBUG
+                                      - TRACE
+                                      type: string
+                                  type: object
+                                file:
+                                  description: |-
+                                    LogLevelSpec
+                                    level mapping if app log level is not standard
+                                      - FATAL -> CRITICAL
+                                      - ERROR -> ERROR
+                                      - WARN -> WARNING
+                                      - INFO -> INFO
+                                      - DEBUG -> DEBUG
+                                      - TRACE -> DEBUG
+
+                                    Default log level is INFO
+                                  properties:
+                                    level:
+                                      default: INFO
+                                      enum:
+                                      - FATAL
+                                      - ERROR
+                                      - WARN
+                                      - INFO
+                                      - DEBUG
+                                      - TRACE
+                                      type: string
+                                  type: object
+                                loggers:
+                                  additionalProperties:
+                                    description: |-
+                                      LogLevelSpec
+                                      level mapping if app log level is not standard
+                                        - FATAL -> CRITICAL
+                                        - ERROR -> ERROR
+                                        - WARN -> WARNING
+                                        - INFO -> INFO
+                                        - DEBUG -> DEBUG
+                                        - TRACE -> DEBUG
+
+                                      Default log level is INFO
+                                    properties:
+                                      level:
+                                        default: INFO
+                                        enum:
+                                        - FATAL
+                                        - ERROR
+                                        - WARN
+                                        - INFO
+                                        - DEBUG
+                                        - TRACE
+                                        type: string
+                                    type: object
+                                  type: object
+                              type: object
+                            type: object
+                          enableVectorAgent:
+                            type: boolean
+                        type: object
+                      resources:
+                        properties:
+                          cpu:
+                            properties:
+                              max:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              min:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          memory:
+                            properties:
+                              limit:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          storage:
+                            properties:
+                              capacity:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                default: 10Gi
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              storageClass:
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                  configOverrides:
+                    additionalProperties:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    type: object
+                  envOverrides:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  podOverrides:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  roleConfig:
+                    properties:
+                      podDisruptionBudget:
+                        description: |-
+                          This struct is used to configure:
+                           1. If PodDisruptionBudgets are created by the operator
+                           2. The allowed number of Pods to be unavailable (`maxUnavailable`)
+                        properties:
+                          enabled:
+                            default: true
+                            description: |-
+                              Whether a PodDisruptionBudget should be written out for this role.
+                              Disabling this enables you to specify your own - custom - one.
+                              Defaults to true.
+                            type: boolean
+                          maxUnavailable:
+                            description: |-
+                              The number of Pods that are allowed to be down because of voluntary disruptions.
+                              If you don't explicitly set this, the operator will use a sane default based
+                              upon knowledge about the individual product.
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                  roleGroups:
+                    additionalProperties:
+                      properties:
+                        cliOverrides:
+                          items:
+                            type: string
+                          type: array
+                        config:
+                          properties:
+                            affinity:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            gracefulShutdownTimeout:
+                              default: 30s
+                              type: string
+                            logging:
+                              properties:
+                                containers:
+                                  additionalProperties:
+                                    properties:
+                                      console:
+                                        description: |-
+                                          LogLevelSpec
+                                          level mapping if app log level is not standard
+                                            - FATAL -> CRITICAL
+                                            - ERROR -> ERROR
+                                            - WARN -> WARNING
+                                            - INFO -> INFO
+                                            - DEBUG -> DEBUG
+                                            - TRACE -> DEBUG
+
+                                          Default log level is INFO
+                                        properties:
+                                          level:
+                                            default: INFO
+                                            enum:
+                                            - FATAL
+                                            - ERROR
+                                            - WARN
+                                            - INFO
+                                            - DEBUG
+                                            - TRACE
+                                            type: string
+                                        type: object
+                                      file:
+                                        description: |-
+                                          LogLevelSpec
+                                          level mapping if app log level is not standard
+                                            - FATAL -> CRITICAL
+                                            - ERROR -> ERROR
+                                            - WARN -> WARNING
+                                            - INFO -> INFO
+                                            - DEBUG -> DEBUG
+                                            - TRACE -> DEBUG
+
+                                          Default log level is INFO
+                                        properties:
+                                          level:
+                                            default: INFO
+                                            enum:
+                                            - FATAL
+                                            - ERROR
+                                            - WARN
+                                            - INFO
+                                            - DEBUG
+                                            - TRACE
+                                            type: string
+                                        type: object
+                                      loggers:
+                                        additionalProperties:
+                                          description: |-
+                                            LogLevelSpec
+                                            level mapping if app log level is not standard
+                                              - FATAL -> CRITICAL
+                                              - ERROR -> ERROR
+                                              - WARN -> WARNING
+                                              - INFO -> INFO
+                                              - DEBUG -> DEBUG
+                                              - TRACE -> DEBUG
+
+                                            Default log level is INFO
+                                          properties:
+                                            level:
+                                              default: INFO
+                                              enum:
+                                              - FATAL
+                                              - ERROR
+                                              - WARN
+                                              - INFO
+                                              - DEBUG
+                                              - TRACE
+                                              type: string
+                                          type: object
+                                        type: object
+                                    type: object
+                                  type: object
+                                enableVectorAgent:
+                                  type: boolean
+                              type: object
+                            resources:
+                              properties:
+                                cpu:
+                                  properties:
+                                    max:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    min:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  type: object
+                                memory:
+                                  properties:
+                                    limit:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  type: object
+                                storage:
+                                  properties:
+                                    capacity:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      default: 10Gi
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    storageClass:
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        configOverrides:
+                          additionalProperties:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          type: object
+                        envOverrides:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        podOverrides:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        replicas:
+                          default: 1
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              broker:
+                properties:
+                  cliOverrides:
+                    items:
+                      type: string
+                    type: array
+                  config:
+                    properties:
+                      affinity:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      gracefulShutdownTimeout:
+                        default: 30s
+                        type: string
+                      logging:
+                        properties:
+                          containers:
+                            additionalProperties:
+                              properties:
+                                console:
+                                  description: |-
+                                    LogLevelSpec
+                                    level mapping if app log level is not standard
+                                      - FATAL -> CRITICAL
+                                      - ERROR -> ERROR
+                                      - WARN -> WARNING
+                                      - INFO -> INFO
+                                      - DEBUG -> DEBUG
+                                      - TRACE -> DEBUG
+
+                                    Default log level is INFO
+                                  properties:
+                                    level:
+                                      default: INFO
+                                      enum:
+                                      - FATAL
+                                      - ERROR
+                                      - WARN
+                                      - INFO
+                                      - DEBUG
+                                      - TRACE
+                                      type: string
+                                  type: object
+                                file:
+                                  description: |-
+                                    LogLevelSpec
+                                    level mapping if app log level is not standard
+                                      - FATAL -> CRITICAL
+                                      - ERROR -> ERROR
+                                      - WARN -> WARNING
+                                      - INFO -> INFO
+                                      - DEBUG -> DEBUG
+                                      - TRACE -> DEBUG
+
+                                    Default log level is INFO
+                                  properties:
+                                    level:
+                                      default: INFO
+                                      enum:
+                                      - FATAL
+                                      - ERROR
+                                      - WARN
+                                      - INFO
+                                      - DEBUG
+                                      - TRACE
+                                      type: string
+                                  type: object
+                                loggers:
+                                  additionalProperties:
+                                    description: |-
+                                      LogLevelSpec
+                                      level mapping if app log level is not standard
+                                        - FATAL -> CRITICAL
+                                        - ERROR -> ERROR
+                                        - WARN -> WARNING
+                                        - INFO -> INFO
+                                        - DEBUG -> DEBUG
+                                        - TRACE -> DEBUG
+
+                                      Default log level is INFO
+                                    properties:
+                                      level:
+                                        default: INFO
+                                        enum:
+                                        - FATAL
+                                        - ERROR
+                                        - WARN
+                                        - INFO
+                                        - DEBUG
+                                        - TRACE
+                                        type: string
+                                    type: object
+                                  type: object
+                              type: object
+                            type: object
+                          enableVectorAgent:
+                            type: boolean
+                        type: object
+                      resources:
+                        properties:
+                          cpu:
+                            properties:
+                              max:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              min:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          memory:
+                            properties:
+                              limit:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          storage:
+                            properties:
+                              capacity:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                default: 10Gi
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              storageClass:
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                  configOverrides:
+                    additionalProperties:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    type: object
+                  envOverrides:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  podOverrides:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  roleConfig:
+                    properties:
+                      podDisruptionBudget:
+                        description: |-
+                          This struct is used to configure:
+                           1. If PodDisruptionBudgets are created by the operator
+                           2. The allowed number of Pods to be unavailable (`maxUnavailable`)
+                        properties:
+                          enabled:
+                            default: true
+                            description: |-
+                              Whether a PodDisruptionBudget should be written out for this role.
+                              Disabling this enables you to specify your own - custom - one.
+                              Defaults to true.
+                            type: boolean
+                          maxUnavailable:
+                            description: |-
+                              The number of Pods that are allowed to be down because of voluntary disruptions.
+                              If you don't explicitly set this, the operator will use a sane default based
+                              upon knowledge about the individual product.
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                  roleGroups:
+                    additionalProperties:
+                      properties:
+                        cliOverrides:
+                          items:
+                            type: string
+                          type: array
+                        config:
+                          properties:
+                            affinity:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            gracefulShutdownTimeout:
+                              default: 30s
+                              type: string
+                            logging:
+                              properties:
+                                containers:
+                                  additionalProperties:
+                                    properties:
+                                      console:
+                                        description: |-
+                                          LogLevelSpec
+                                          level mapping if app log level is not standard
+                                            - FATAL -> CRITICAL
+                                            - ERROR -> ERROR
+                                            - WARN -> WARNING
+                                            - INFO -> INFO
+                                            - DEBUG -> DEBUG
+                                            - TRACE -> DEBUG
+
+                                          Default log level is INFO
+                                        properties:
+                                          level:
+                                            default: INFO
+                                            enum:
+                                            - FATAL
+                                            - ERROR
+                                            - WARN
+                                            - INFO
+                                            - DEBUG
+                                            - TRACE
+                                            type: string
+                                        type: object
+                                      file:
+                                        description: |-
+                                          LogLevelSpec
+                                          level mapping if app log level is not standard
+                                            - FATAL -> CRITICAL
+                                            - ERROR -> ERROR
+                                            - WARN -> WARNING
+                                            - INFO -> INFO
+                                            - DEBUG -> DEBUG
+                                            - TRACE -> DEBUG
+
+                                          Default log level is INFO
+                                        properties:
+                                          level:
+                                            default: INFO
+                                            enum:
+                                            - FATAL
+                                            - ERROR
+                                            - WARN
+                                            - INFO
+                                            - DEBUG
+                                            - TRACE
+                                            type: string
+                                        type: object
+                                      loggers:
+                                        additionalProperties:
+                                          description: |-
+                                            LogLevelSpec
+                                            level mapping if app log level is not standard
+                                              - FATAL -> CRITICAL
+                                              - ERROR -> ERROR
+                                              - WARN -> WARNING
+                                              - INFO -> INFO
+                                              - DEBUG -> DEBUG
+                                              - TRACE -> DEBUG
+
+                                            Default log level is INFO
+                                          properties:
+                                            level:
+                                              default: INFO
+                                              enum:
+                                              - FATAL
+                                              - ERROR
+                                              - WARN
+                                              - INFO
+                                              - DEBUG
+                                              - TRACE
+                                              type: string
+                                          type: object
+                                        type: object
+                                    type: object
+                                  type: object
+                                enableVectorAgent:
+                                  type: boolean
+                              type: object
+                            resources:
+                              properties:
+                                cpu:
+                                  properties:
+                                    max:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    min:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  type: object
+                                memory:
+                                  properties:
+                                    limit:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  type: object
+                                storage:
+                                  properties:
+                                    capacity:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      default: 10Gi
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    storageClass:
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        configOverrides:
+                          additionalProperties:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          type: object
+                        envOverrides:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        podOverrides:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        replicas:
+                          default: 1
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              clusterConfig:
+                properties:
+                  authentication:
+                    items:
+                      properties:
+                        authenticationClass:
+                          type: string
+                      required:
+                      - authenticationClass
+                      type: object
+                    type: array
+                  clusterDomain:
+                    default: cluster.local
+                    type: string
+                  ingressHost:
+                    default: example.com
+                    type: string
+                  scaleDownPolicy:
+                    description: ScaleDownPolicySpec defines the scale-down policy
+                      for Doris cluster components.
+                    properties:
+                      backendStrategy:
+                        default: decommission
+                        enum:
+                        - decommission
+                        - force-drop
+                        type: string
+                      decommissionTimeout:
+                        default: 2h
+                        description: |-
+                          DecommissionTimeout is the maximum duration to wait for BE decommission to complete.
+                          After this timeout, the operator will force-drop the node instead of waiting for data migration.
+                          NOTE: This field is reserved for future implementation; currently decommission will wait indefinitely.
+                        type: string
+                      frontendStrategy:
+                        default: drop-observer
+                        enum:
+                        - drop-observer
+                        type: string
+                    type: object
+                  vectorAggregatorConfigMapName:
+                    type: string
+                type: object
+              clusterOperation:
+                description: ClusterOperationSpec defines the desired state of ClusterOperation
+                properties:
+                  reconciliationPaused:
+                    default: false
+                    type: boolean
+                  stopped:
+                    default: false
+                    type: boolean
+                type: object
+              frontend:
+                properties:
+                  cliOverrides:
+                    items:
+                      type: string
+                    type: array
+                  config:
+                    properties:
+                      affinity:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      gracefulShutdownTimeout:
+                        default: 30s
+                        type: string
+                      logging:
+                        properties:
+                          containers:
+                            additionalProperties:
+                              properties:
+                                console:
+                                  description: |-
+                                    LogLevelSpec
+                                    level mapping if app log level is not standard
+                                      - FATAL -> CRITICAL
+                                      - ERROR -> ERROR
+                                      - WARN -> WARNING
+                                      - INFO -> INFO
+                                      - DEBUG -> DEBUG
+                                      - TRACE -> DEBUG
+
+                                    Default log level is INFO
+                                  properties:
+                                    level:
+                                      default: INFO
+                                      enum:
+                                      - FATAL
+                                      - ERROR
+                                      - WARN
+                                      - INFO
+                                      - DEBUG
+                                      - TRACE
+                                      type: string
+                                  type: object
+                                file:
+                                  description: |-
+                                    LogLevelSpec
+                                    level mapping if app log level is not standard
+                                      - FATAL -> CRITICAL
+                                      - ERROR -> ERROR
+                                      - WARN -> WARNING
+                                      - INFO -> INFO
+                                      - DEBUG -> DEBUG
+                                      - TRACE -> DEBUG
+
+                                    Default log level is INFO
+                                  properties:
+                                    level:
+                                      default: INFO
+                                      enum:
+                                      - FATAL
+                                      - ERROR
+                                      - WARN
+                                      - INFO
+                                      - DEBUG
+                                      - TRACE
+                                      type: string
+                                  type: object
+                                loggers:
+                                  additionalProperties:
+                                    description: |-
+                                      LogLevelSpec
+                                      level mapping if app log level is not standard
+                                        - FATAL -> CRITICAL
+                                        - ERROR -> ERROR
+                                        - WARN -> WARNING
+                                        - INFO -> INFO
+                                        - DEBUG -> DEBUG
+                                        - TRACE -> DEBUG
+
+                                      Default log level is INFO
+                                    properties:
+                                      level:
+                                        default: INFO
+                                        enum:
+                                        - FATAL
+                                        - ERROR
+                                        - WARN
+                                        - INFO
+                                        - DEBUG
+                                        - TRACE
+                                        type: string
+                                    type: object
+                                  type: object
+                              type: object
+                            type: object
+                          enableVectorAgent:
+                            type: boolean
+                        type: object
+                      resources:
+                        properties:
+                          cpu:
+                            properties:
+                              max:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              min:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          memory:
+                            properties:
+                              limit:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          storage:
+                            properties:
+                              capacity:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                default: 10Gi
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              storageClass:
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                  configOverrides:
+                    additionalProperties:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    type: object
+                  envOverrides:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  podOverrides:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  roleConfig:
+                    properties:
+                      podDisruptionBudget:
+                        description: |-
+                          This struct is used to configure:
+                           1. If PodDisruptionBudgets are created by the operator
+                           2. The allowed number of Pods to be unavailable (`maxUnavailable`)
+                        properties:
+                          enabled:
+                            default: true
+                            description: |-
+                              Whether a PodDisruptionBudget should be written out for this role.
+                              Disabling this enables you to specify your own - custom - one.
+                              Defaults to true.
+                            type: boolean
+                          maxUnavailable:
+                            description: |-
+                              The number of Pods that are allowed to be down because of voluntary disruptions.
+                              If you don't explicitly set this, the operator will use a sane default based
+                              upon knowledge about the individual product.
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                  roleGroups:
+                    additionalProperties:
+                      properties:
+                        cliOverrides:
+                          items:
+                            type: string
+                          type: array
+                        config:
+                          properties:
+                            affinity:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            gracefulShutdownTimeout:
+                              default: 30s
+                              type: string
+                            logging:
+                              properties:
+                                containers:
+                                  additionalProperties:
+                                    properties:
+                                      console:
+                                        description: |-
+                                          LogLevelSpec
+                                          level mapping if app log level is not standard
+                                            - FATAL -> CRITICAL
+                                            - ERROR -> ERROR
+                                            - WARN -> WARNING
+                                            - INFO -> INFO
+                                            - DEBUG -> DEBUG
+                                            - TRACE -> DEBUG
+
+                                          Default log level is INFO
+                                        properties:
+                                          level:
+                                            default: INFO
+                                            enum:
+                                            - FATAL
+                                            - ERROR
+                                            - WARN
+                                            - INFO
+                                            - DEBUG
+                                            - TRACE
+                                            type: string
+                                        type: object
+                                      file:
+                                        description: |-
+                                          LogLevelSpec
+                                          level mapping if app log level is not standard
+                                            - FATAL -> CRITICAL
+                                            - ERROR -> ERROR
+                                            - WARN -> WARNING
+                                            - INFO -> INFO
+                                            - DEBUG -> DEBUG
+                                            - TRACE -> DEBUG
+
+                                          Default log level is INFO
+                                        properties:
+                                          level:
+                                            default: INFO
+                                            enum:
+                                            - FATAL
+                                            - ERROR
+                                            - WARN
+                                            - INFO
+                                            - DEBUG
+                                            - TRACE
+                                            type: string
+                                        type: object
+                                      loggers:
+                                        additionalProperties:
+                                          description: |-
+                                            LogLevelSpec
+                                            level mapping if app log level is not standard
+                                              - FATAL -> CRITICAL
+                                              - ERROR -> ERROR
+                                              - WARN -> WARNING
+                                              - INFO -> INFO
+                                              - DEBUG -> DEBUG
+                                              - TRACE -> DEBUG
+
+                                            Default log level is INFO
+                                          properties:
+                                            level:
+                                              default: INFO
+                                              enum:
+                                              - FATAL
+                                              - ERROR
+                                              - WARN
+                                              - INFO
+                                              - DEBUG
+                                              - TRACE
+                                              type: string
+                                          type: object
+                                        type: object
+                                    type: object
+                                  type: object
+                                enableVectorAgent:
+                                  type: boolean
+                              type: object
+                            resources:
+                              properties:
+                                cpu:
+                                  properties:
+                                    max:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    min:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  type: object
+                                memory:
+                                  properties:
+                                    limit:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  type: object
+                                storage:
+                                  properties:
+                                    capacity:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      default: 10Gi
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    storageClass:
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        configOverrides:
+                          additionalProperties:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          type: object
+                        envOverrides:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        podOverrides:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        replicas:
+                          default: 1
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              image:
+                properties:
+                  custom:
+                    type: string
+                  kubedoopVersion:
+                    default: 0.0.0-dev
+                    type: string
+                  productVersion:
+                    default: 3.7.1
+                    type: string
+                  pullPolicy:
+                    default: IfNotPresent
+                    description: PullPolicy describes a policy for if/when to pull
+                      a container image
+                    type: string
+                  pullSecretName:
+                    type: string
+                  repository:
+                    default: quay.io/zncdatadev
+                    type: string
+                type: object
+            required:
+            - backend
+            - frontend
+            type: object
+          status:
+            description: DorisClusterStatus defines the observed state of DorisCluster
+            properties:
+              authInitialized:
+                description: |-
+                  AuthInitialized indicates whether the admin user specified in authSecret
+                  has been created and granted privileges in the Doris cluster.
+                type: boolean
+              backendNodes:
+                items:
+                  description: NodeStatus represents the status of a Doris cluster
+                    node
+                  properties:
+                    alive:
+                      type: boolean
+                    host:
+                      type: string
+                    name:
+                      type: string
+                    phase:
+                      description: 'Phase is the node lifecycle phase: Registered
+                        / Decommissioning / Decommissioned / ForceDropped'
+                      type: string
+                    role:
+                      description: Role is the node role (follower/observer for FE,
+                        empty for BE/Broker)
+                      type: string
+                  type: object
+                type: array
+              brokerNodes:
+                items:
+                  description: NodeStatus represents the status of a Doris cluster
+                    node
+                  properties:
+                    alive:
+                      type: boolean
+                    host:
+                      type: string
+                    name:
+                      type: string
+                    phase:
+                      description: 'Phase is the node lifecycle phase: Registered
+                        / Decommissioning / Decommissioned / ForceDropped'
+                      type: string
+                    role:
+                      description: Role is the node role (follower/observer for FE,
+                        empty for BE/Broker)
+                      type: string
+                  type: object
+                type: array
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              frontendNodes:
+                items:
+                  description: NodeStatus represents the status of a Doris cluster
+                    node
+                  properties:
+                    alive:
+                      type: boolean
+                    host:
+                      type: string
+                    name:
+                      type: string
+                    phase:
+                      description: 'Phase is the node lifecycle phase: Registered
+                        / Decommissioning / Decommissioned / ForceDropped'
+                      type: string
+                    role:
+                      description: Role is the node role (follower/observer for FE,
+                        empty for BE/Broker)
+                      type: string
+                  type: object
+                type: array
+              generation:
+                format: int64
+                type: integer
+              name:
+                type: string
+              type:
+                type: string
+              urls:
+                items:
+                  description: URL is a URL with a name
+                  properties:
+                    name:
+                      type: string
+                    url:
+                      type: string
+                  required:
+                  - name
+                  - url
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy/helm/doris-operator/templates/_helpers.tpl
+++ b/deploy/helm/doris-operator/templates/_helpers.tpl
@@ -1,0 +1,53 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "doris-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "doris-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "doris-operator.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "doris-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "doris-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "doris-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "doris-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "doris-operator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/doris-operator/templates/clusterrole.yaml
+++ b/deploy/helm/doris-operator/templates/clusterrole.yaml
@@ -1,0 +1,174 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "doris-operator.fullname" . }}
+  labels:
+    {{- include "doris-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - doris.kubedoop.dev
+  resources:
+  - dorisclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - doris.kubedoop.dev
+  resources:
+  - dorisclusters/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - doris.kubedoop.dev
+  resources:
+  - dorisclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+{{- include "doris-operator.extraPermissions" . }}

--- a/deploy/helm/doris-operator/templates/clusterrolebinding.yaml
+++ b/deploy/helm/doris-operator/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "doris-operator.fullname" . }}
+  labels:
+    {{- include "doris-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "doris-operator.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "doris-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/deploy/helm/doris-operator/templates/deployment.yaml
+++ b/deploy/helm/doris-operator/templates/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "doris-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "doris-operator.labels" . | nindent 4 }}
+    control-plane: controller-manager
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "doris-operator.selectorLabels" . | nindent 6 }}
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        {{- include "doris-operator.selectorLabels" . | nindent 8 }}
+        control-plane: controller-manager
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "doris-operator.serviceAccountName" . }}
+      terminationGracePeriodSeconds: 10
+      containers:
+      - command:
+        - /manager
+        args:
+          - --leader-elect
+          - --health-probe-bind-address={{ .Values.healthProbe.bindAddress }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+        name: manager
+        {{- with .Values.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: {{ .Values.healthProbe.bindAddress }}
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: {{ .Values.healthProbe.bindAddress }}
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        {{- with .Values.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/doris-operator/templates/metricsservice.yaml
+++ b/deploy/helm/doris-operator/templates/metricsservice.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "doris-operator.fullname" . }}-metrics-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "doris-operator.labels" . | nindent 4 }}
+    control-plane: controller-manager
+  {{- with .Values.metrics.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.metrics.service.type }}
+  ports:
+  - name: {{ if .Values.metrics.secure }}https{{ else }}http{{ end }}
+    port: {{ if .Values.metrics.secure }}8443{{ else }}{{ regexReplaceAll ":" .Values.healthProbe.bindAddress "" }}{{ end }}
+    protocol: TCP
+    targetPort: {{ if .Values.metrics.secure }}8443{{ else }}{{ regexReplaceAll ":" .Values.healthProbe.bindAddress "" }}{{ end }}
+  selector:
+    {{- include "doris-operator.selectorLabels" . | nindent 4 }}
+    control-plane: controller-manager
+{{- end }}

--- a/deploy/helm/doris-operator/templates/serviceaccount.yaml
+++ b/deploy/helm/doris-operator/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "doris-operator.serviceAccountName" . }}
+  labels:
+    {{- include "doris-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}

--- a/deploy/helm/doris-operator/templates/servicemonitor.yaml
+++ b/deploy/helm/doris-operator/templates/servicemonitor.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "doris-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "doris-operator.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "doris-operator.selectorLabels" . | nindent 6 }}
+      control-plane: controller-manager
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+  - port: {{ if .Values.metrics.secure }}https{{ else }}http{{ end }}
+    path: {{ .Values.serviceMonitor.path }}
+    interval: {{ .Values.serviceMonitor.interval }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    {{- if .Values.metrics.secure }}
+    tlsConfig:
+      insecureSkipVerify: {{ .Values.serviceMonitor.tlsConfig.insecureSkipVerify }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/doris-operator/values.yaml
+++ b/deploy/helm/doris-operator/values.yaml
@@ -1,0 +1,57 @@
+# Default values for doris-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: quay.io/zncdatadev/doris-operator
+  pullPolicy: IfNotPresent
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  automount: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Metrics service configuration
+metrics:
+  enabled: true
+  secure: false
+  service:
+    type: ClusterIP
+    annotations: {}
+
+# Health probe configuration
+healthProbe:
+  bindAddress: ":8081"
+
+# ServiceMonitor configuration for Prometheus Operator
+serviceMonitor:
+  enabled: false
+  additionalLabels: {}
+  interval: 30s
+  scrapeTimeout: 10s
+  path: /metrics
+  tlsConfig:
+    insecureSkipVerify: false


### PR DESCRIPTION
## Background

Per release alignment checklist, doris-operator needs a Helm Chart system to enable chart-lint-test and release-chart CI jobs. Currently doris-operator has no Helm Chart directory, which blocks PR-D (chart-lint-test split) and PR-F (release guide).

## Changes

**Helm Chart scaffolding (`deploy/helm/doris-operator/`):**
- Chart.yaml (version: 0.0.0-dev)
- values.yaml (image, resources, metrics, ServiceMonitor)
- templates: _helpers.tpl, serviceaccount, clusterrole, clusterrolebinding, deployment, metricsservice, servicemonitor
- crds/crds.yaml (synced from config/crd/bases/)

**CI configs:**
- .github/configs/ct-lint.yaml
- .github/configs/ct-install.yaml

**Makefile targets:**
- `helm-crd-sync`: sync CRDs to helm chart
- `helm-chart-package`: package helm chart
- `helm-chart-publish`: publish chart to OCI registry

## Reference

Adapted from commons-operator baseline.

## Impact

- 13 files changed (12 new, 1 modified)
- No functional change to operator code
- Prerequisite for PR-D (chart-lint-test split)