### PR TITLE
fix: correct productVersion kubebuilder default from 3.7.1 to 2.1.8

### DIFF
--- a/api/v1alpha1/image.go
+++ b/api/v1alpha1/image.go
@@ -26,7 +26,7 @@ type ImageSpec struct {
 	KubedoopVersion string `json:"kubedoopVersion,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="3.7.1"
+	// +kubebuilder:default="2.1.8"
 	ProductVersion string `json:"productVersion,omitempty"`
 
 	// +kubebuilder:validation:Optional


### PR DESCRIPTION
## Background

Per release alignment checklist PR-E, the kubebuilder default annotation for ProductVersion was "3.7.1" but the actual DefaultProductVersion constant is "2.1.8". This mismatch means the CRD OpenAPI schema shows an incorrect default value to users.

## Fix

- Correct kubebuilder:default from "3.7.1" to "2.1.8" in api/v1alpha1/image.go
- Regenerate CRD manifests with `make manifests`

## Impact

- 1 file changed + 1 generated CRD file updated
- Fixes CRD schema default value to match actual runtime behavior