### PR TITLE
fix(ci): handle first-release tag detection in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,12 +172,12 @@ jobs:
           # Exclude -dev pre-release tags only when looking for the previous tag,
           # not when matching the current tag itself
           CURRENT_TAG="${{ github.ref_name }}"
-          PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -A1 "^${CURRENT_TAG}$" | tail -n1 | grep -v '\-dev$')
+          PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -A1 "^${CURRENT_TAG}$" | tail -n1 | grep -v '\-dev$' || true)
 
           # If the -dev tag itself was the only match (no previous stable tag found),
           # try again excluding -dev to find the actual previous stable release
           if [[ -z "$PREVIOUS_TAG" ]]; then
-            PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -v '\-dev$' | grep -A1 "^${CURRENT_TAG}$" | tail -n1)
+            PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -v '\-dev$' | grep -A1 "^${CURRENT_TAG}$" | tail -n1 || true)
           fi
 
           # First release detection
@@ -223,6 +223,12 @@ jobs:
       - name: Check chart changes
         id: check-changes
         run: |
+          # If first release (no since_commit), inherit changed=true from commit-range
+          if [[ -z "${{ steps.commit-range.outputs.since_commit }}" ]]; then
+            echo "First release detected in previous step - skipping ct list-changed"
+            exit 0
+          fi
+
           # Check for changes in chart directory using both --since and --target-branch parameters
           if ! changed=$(ct list-changed \
             --chart-dirs deploy/helm \


### PR DESCRIPTION
## Problem

Two issues in the release workflow's `chart-lint-helm` job when the repository has no previous stable tag (first release scenario, e.g. only `0.4.0-dev` tag exists):

1. **`set -e` abort on empty grep**: `grep -v '\-dev$'` returns exit code 1 when no match is found (e.g. only tag is `0.4.0-dev`). Under `bash -e`, the script terminates before reaching the first-release detection `exit 0`.

2. **Empty `--since` causes ct list-changed failure**: After first-release detection sets `changed=true` but not `since_commit`, the subsequent `Check chart changes` step passes `--since "" ` to `ct list-changed`, which fails.

Both issues also affect first **stable** release (e.g. `0.4.0` tag when only `0.4.0-dev` + `0.4.0` exist — grep matches `0.4.0-dev` then filters it out, returning empty).

## Fix

1. Add `|| true` to both `grep -v '\-dev$'` pipelines to prevent `set -e` termination
2. Skip `ct list-changed` when `since_commit` is empty, inheriting `changed=true` from the commit-range step

## Scenarios verified

| Scenario | Tags | Before fix | After fix |
|---|---|---|---|
| First -dev release | `0.4.0-dev` | ❌ set -e abort | ✅ first release detected |
| First stable release | `0.4.0 + 0.4.0-dev` | ❌ set -e abort | ✅ first release detected |
| Stable w/ previous | `0.4.0 + 0.4.0-dev + 0.3.0` | ✅ (works) | ✅ (no change) |
| Subsequent -dev | `0.5.0-dev + 0.4.0 ...` | ✅ (works) | ✅ (no change)