### PR TITLE
fix(ci): align docker-buildx with zookeeper-operator baseline for multi-arch signing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,13 +134,15 @@ docker-push: ## Push docker image with the manager.
 # - be able to push the image to your registry (i.e. if you do not set a valid value via IMG=<myregistry/image:<tag>> then the export will fail)
 # To adequately provide solutions that are compatible with multiple platforms, you should consider using this option.
 PLATFORMS ?= linux/arm64,linux/amd64
-BUILDX_METADATA_FILE ?= docker-digests.json	# The file to store the digests of the images built by buildx
 .PHONY: docker-buildx
 docker-buildx: ## Build and push docker image for the manager for cross-platform support
+	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
+	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- $(CONTAINER_TOOL) buildx create --name $(PROJECT_NAME)-builder
 	$(CONTAINER_TOOL) buildx use $(PROJECT_NAME)-builder
-	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --build-arg LDFLAGS=$(LDFLAGS) --tag ${IMG} --metadata-file ${BUILDX_METADATA_FILE} -f Dockerfile .
+	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --build-arg LDFLAGS=$(LDFLAGS) --tag ${IMG} --metadata-file docker-digests.json -f Dockerfile.cross .
 	- $(CONTAINER_TOOL) buildx rm $(PROJECT_NAME)-builder
+	rm Dockerfile.cross
 
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.


### PR DESCRIPTION
## Problem

The Release Image job's **Sign operator image** step failed with exit code 2 during the 0.4.0-dev tag push release workflow (run #27288833153). All other 11 jobs passed successfully.

**Failure chain:**
```
Release Image
  ├─ Build and push operator → ✅ success
  └─ Sign operator image     → ❌ exit code 2
```

## Root Cause

`docker-buildx` was missing the `Dockerfile.cross` generation step that injects `--platform=${BUILDPLATFORM}` into the builder stage FROM line. Without this, buildx multi-arch builds may produce an incomplete or malformed `docker-digests.json` metadata file, causing the sign-image composite action's `jq` parse to fail.

## Changes

- Add `sed` command to generate `Dockerfile.cross` with `--platform=${BUILDPLATFORM}`
- Use `Dockerfile.cross` instead of `Dockerfile` for the buildx build
- Hardcode `docker-digests.json` as metadata file (matching zookeeper-operator)
- Remove unused `BUILDX_METADATA_FILE` variable
- Clean up `Dockerfile.cross` after build

## Verification

```diff
- Aligns with zookeeper-operator baseline (the reference 0.4.0-dev release)
```

Diff against zookeeper-operator `docker-buildx` target: **zero difference**.