### PR TITLE
fix(e2e): honor PRODUCT_VERSION in chainsaw values and official image path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,3 @@ cover.out
 
 docker-digests.json
 .worktree/
-
-# generated chainsaw values
-test/e2e/.values.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ cover.out
 
 docker-digests.json
 .worktree/
+
+# generated chainsaw values
+test/e2e/.values.yaml

--- a/Makefile
+++ b/Makefile
@@ -284,6 +284,10 @@ CHAINSAW ?= $(LOCALBIN)/chainsaw
 CHAINSAW_VERSION ?= v0.2.13
 CHAINSAW_CLUSTER ?= chainsaw-${PROJECT_NAME}
 CHAINSAW_KUBECONFIG ?= .kubeconfig
+# Chainsaw only resolves ($values.*) bindings from files passed via --values,
+# so the product version selected by the CI matrix must be written to a values
+# file before running the tests. See the chainsaw-values target.
+CHAINSAW_VALUES ?= test/e2e/.values.yaml
 # KIND_K8S_VERSION refers to the version of Kubernetes to be used by kind node image.
 # The version only effects e2e tests.
 # When run `kind create --image kindest/node:v${KIND_K8S_VERSION}`, the node image version of k8s will be used to create the kind cluster,
@@ -330,16 +334,20 @@ setup-chainsaw-e2e: chainsaw docker-build ## Run the chainsaw setup
 
 
 .PHONY: chart-e2e
-chart-e2e: setup-chainsaw-cluster chainsaw docker-build helm-chart-package ## Run e2e tests with Helm chart deployment
+chart-e2e: setup-chainsaw-cluster chainsaw docker-build helm-chart-package chainsaw-values ## Run e2e tests with Helm chart deployment
 	"$(KIND)" --name $(CHAINSAW_CLUSTER) load docker-image "$(IMG)"
 	"$(HELM)" upgrade --install --create-namespace --namespace $(PROJECT_NAME) \
 		--kubeconfig $(CHAINSAW_KUBECONFIG) --wait $(PROJECT_NAME) \
 		target/charts/$(PROJECT_NAME)-$(VERSION).tgz
-	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
+	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/ --values $(CHAINSAW_VALUES)
+
+.PHONY: chainsaw-values
+chainsaw-values: ## Generate the chainsaw values file from PRODUCT_VERSION. When unset, null lets the operator default apply.
+	@echo "product_version: $${PRODUCT_VERSION:-null}" > $(CHAINSAW_VALUES)
 
 .PHONY: chainsaw-e2e
-chainsaw-e2e: ## Run the chainsaw e2e tests
-	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
+chainsaw-e2e: chainsaw-values ## Run the chainsaw e2e tests
+	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/ --values $(CHAINSAW_VALUES)
 
 .PHONY: cleanup-chainsaw-e2e
 cleanup-chainsaw-e2e: ## Run the chainsaw cleanup

--- a/Makefile
+++ b/Makefile
@@ -281,13 +281,9 @@ helm-chart-publish: helm-chart-package ## Publish helm chart for the operator.
 ##@ Chainsaw E2E
 
 CHAINSAW ?= $(LOCALBIN)/chainsaw
-CHAINSAW_VERSION ?= v0.2.13
+CHAINSAW_VERSION ?= v0.2.15
 CHAINSAW_CLUSTER ?= chainsaw-${PROJECT_NAME}
 CHAINSAW_KUBECONFIG ?= .kubeconfig
-# Chainsaw only resolves ($values.*) bindings from files passed via --values,
-# so the product version selected by the CI matrix must be written to a values
-# file before running the tests. See the chainsaw-values target.
-CHAINSAW_VALUES ?= test/e2e/.values.yaml
 # KIND_K8S_VERSION refers to the version of Kubernetes to be used by kind node image.
 # The version only effects e2e tests.
 # When run `kind create --image kindest/node:v${KIND_K8S_VERSION}`, the node image version of k8s will be used to create the kind cluster,
@@ -334,20 +330,16 @@ setup-chainsaw-e2e: chainsaw docker-build ## Run the chainsaw setup
 
 
 .PHONY: chart-e2e
-chart-e2e: setup-chainsaw-cluster chainsaw docker-build helm-chart-package chainsaw-values ## Run e2e tests with Helm chart deployment
+chart-e2e: setup-chainsaw-cluster chainsaw docker-build helm-chart-package ## Run e2e tests with Helm chart deployment
 	"$(KIND)" --name $(CHAINSAW_CLUSTER) load docker-image "$(IMG)"
 	"$(HELM)" upgrade --install --create-namespace --namespace $(PROJECT_NAME) \
 		--kubeconfig $(CHAINSAW_KUBECONFIG) --wait $(PROJECT_NAME) \
 		target/charts/$(PROJECT_NAME)-$(VERSION).tgz
-	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/ --values $(CHAINSAW_VALUES)
-
-.PHONY: chainsaw-values
-chainsaw-values: ## Generate the chainsaw values file from PRODUCT_VERSION. When unset, null lets the operator default apply.
-	@echo "product_version: $${PRODUCT_VERSION:-null}" > $(CHAINSAW_VALUES)
+	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/ --set product_version=$(PRODUCT_VERSION)
 
 .PHONY: chainsaw-e2e
-chainsaw-e2e: chainsaw-values ## Run the chainsaw e2e tests
-	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/ --values $(CHAINSAW_VALUES)
+chainsaw-e2e: ## Run the chainsaw e2e tests
+	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/ --set product_version=$(PRODUCT_VERSION)
 
 .PHONY: cleanup-chainsaw-e2e
 cleanup-chainsaw-e2e: ## Run the chainsaw cleanup

--- a/Makefile
+++ b/Makefile
@@ -281,7 +281,7 @@ helm-chart-publish: helm-chart-package ## Publish helm chart for the operator.
 ##@ Chainsaw E2E
 
 CHAINSAW ?= $(LOCALBIN)/chainsaw
-CHAINSAW_VERSION ?= v0.2.15
+CHAINSAW_VERSION ?= v0.2.14
 CHAINSAW_CLUSTER ?= chainsaw-${PROJECT_NAME}
 CHAINSAW_KUBECONFIG ?= .kubeconfig
 # KIND_K8S_VERSION refers to the version of Kubernetes to be used by kind node image.

--- a/internal/controller/common/image_helper.go
+++ b/internal/controller/common/image_helper.go
@@ -11,22 +11,33 @@ import (
 
 // GetImage returns the image for the given component.
 //
-// When imageSpec is nil (no image configured in the CR), it falls back to the
-// official apache/doris per-component images (e.g. apache/doris:fe-2.1.8).
+// Unless imageSpec.Custom is set, it resolves to the official apache/doris
+// per-component images (e.g. apache/doris:fe-2.1.8), honoring
+// imageSpec.ProductVersion when provided.
 //
-// When imageSpec is provided, it delegates to TransformImage which builds the
-// unified quay.io/zncdatadev/doris:<version>-kubedoop<kubedoop-version> image.
+// When imageSpec.Custom is set, it delegates to TransformImage so the custom
+// image is used as-is.
 //
-// TODO: Once the custom unified image is production-ready, remove the nil
-// fallback and always use TransformImage.
+// TODO: Once the unified quay.io/zncdatadev/doris:<version>-kubedoop<version>
+// image is published and production-ready, always use TransformImage instead
+// of the official per-component images.
 func GetImage(imageSpec *dorisv1alpha1.ImageSpec, componentType constants.ComponentType) *opgoutil.Image {
-	if imageSpec == nil {
-		return &opgoutil.Image{
-			Custom:     fmt.Sprintf("%s:%s-%s", constants.OfficialImageRepository, componentType, constants.DefaultProductVersion),
-			PullPolicy: corev1.PullIfNotPresent,
-		}
+	if imageSpec != nil && imageSpec.Custom != "" {
+		return dorisv1alpha1.TransformImage(imageSpec)
 	}
-	return dorisv1alpha1.TransformImage(imageSpec)
+	productVersion := constants.DefaultProductVersion
+	pullSecretName := ""
+	if imageSpec != nil {
+		if imageSpec.ProductVersion != "" {
+			productVersion = imageSpec.ProductVersion
+		}
+		pullSecretName = imageSpec.PullSecretName
+	}
+	return &opgoutil.Image{
+		Custom:         fmt.Sprintf("%s:%s-%s", constants.OfficialImageRepository, componentType, productVersion),
+		PullPolicy:     GetPullPolicy(imageSpec),
+		PullSecretName: pullSecretName,
+	}
 }
 
 // GetInitContainerImage returns the image to use for init containers

--- a/internal/controller/common/image_helper_test.go
+++ b/internal/controller/common/image_helper_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2025 zncdatadev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	dorisv1alpha1 "github.com/zncdatadev/doris-operator/api/v1alpha1"
+	"github.com/zncdatadev/doris-operator/internal/controller/constants"
+)
+
+func TestGetImage(t *testing.T) {
+	pullAlways := corev1.PullAlways
+
+	tests := []struct {
+		name           string
+		imageSpec      *dorisv1alpha1.ImageSpec
+		componentType  constants.ComponentType
+		wantImage      string
+		wantPullPolicy corev1.PullPolicy
+	}{
+		{
+			name:           "nil spec falls back to official image with default version",
+			imageSpec:      nil,
+			componentType:  constants.ComponentTypeFE,
+			wantImage:      "apache/doris:fe-" + constants.DefaultProductVersion,
+			wantPullPolicy: corev1.PullIfNotPresent,
+		},
+		{
+			name:           "productVersion overrides default in official image",
+			imageSpec:      &dorisv1alpha1.ImageSpec{ProductVersion: "3.0.3"},
+			componentType:  constants.ComponentTypeBE,
+			wantImage:      "apache/doris:be-3.0.3",
+			wantPullPolicy: corev1.PullIfNotPresent,
+		},
+		{
+			name: "defaulted spec without explicit productVersion uses default version",
+			imageSpec: &dorisv1alpha1.ImageSpec{
+				Repo:            dorisv1alpha1.DefaultRepository,
+				KubedoopVersion: dorisv1alpha1.DefaultKubedoopVersion,
+			},
+			componentType:  constants.ComponentTypeBroker,
+			wantImage:      "apache/doris:broker-" + constants.DefaultProductVersion,
+			wantPullPolicy: corev1.PullIfNotPresent,
+		},
+		{
+			name: "pull policy from spec is honored on official image path",
+			imageSpec: &dorisv1alpha1.ImageSpec{
+				ProductVersion: "2.1.8",
+				PullPolicy:     &pullAlways,
+			},
+			componentType:  constants.ComponentTypeFE,
+			wantImage:      "apache/doris:fe-2.1.8",
+			wantPullPolicy: corev1.PullAlways,
+		},
+		{
+			name:           "custom image bypasses official image path",
+			imageSpec:      &dorisv1alpha1.ImageSpec{Custom: "my.repo.org/doris:custom"},
+			componentType:  constants.ComponentTypeFE,
+			wantImage:      "my.repo.org/doris:custom",
+			wantPullPolicy: corev1.PullIfNotPresent,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			img := GetImage(tt.imageSpec, tt.componentType)
+			if got := img.String(); got != tt.wantImage {
+				t.Errorf("GetImage() image = %q, want %q", got, tt.wantImage)
+			}
+			if img.PullPolicy != tt.wantPullPolicy {
+				t.Errorf("GetImage() pull policy = %q, want %q", img.PullPolicy, tt.wantPullPolicy)
+			}
+		})
+	}
+}
+
+func TestGetImagePullSecret(t *testing.T) {
+	img := GetImage(&dorisv1alpha1.ImageSpec{
+		ProductVersion: "3.0.3",
+		PullSecretName: "my-pull-secret",
+	}, constants.ComponentTypeFE)
+	if img.PullSecretName != "my-pull-secret" {
+		t.Errorf("GetImage() pull secret = %q, want %q", img.PullSecretName, "my-pull-secret")
+	}
+}

--- a/test/e2e/auth-secret/chainsaw-test.yaml
+++ b/test/e2e/auth-secret/chainsaw-test.yaml
@@ -3,6 +3,9 @@ kind: Test
 metadata:
   name: auth-secret
 spec:
+  bindings:
+  - name: doris_version
+    value: ($values.product_version)
   steps:
   - name: create admin secret
     try:

--- a/test/e2e/auth-secret/doris.yaml
+++ b/test/e2e/auth-secret/doris.yaml
@@ -5,6 +5,8 @@ metadata:
     app.kubernetes.io/name: doris-operator
   name: doriscluster-sample
 spec:
+  image:
+    productVersion: ($values.product_version)
   clusterConfig: {}
   authSecret:
     secretName: doris-admin-secret

--- a/test/e2e/authentication/ldap/chainsaw-test.yaml
+++ b/test/e2e/authentication/ldap/chainsaw-test.yaml
@@ -4,6 +4,8 @@ metadata:
   name: ldap
 spec:
   bindings:
+  - name: doris_version
+    value: ($values.product_version)
   - name: LDAP_ADMIN_USERNAME
     value: admin
   - name: LDAP_ADMIN_PASSWORD

--- a/test/e2e/authentication/ldap/doris.yaml
+++ b/test/e2e/authentication/ldap/doris.yaml
@@ -6,6 +6,8 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: doriscluster-sample
 spec:
+  image:
+    productVersion: ($values.product_version)
   clusterConfig:
     authentication:
       - authenticationClass: ldap

--- a/test/e2e/scale-config/chainsaw-test.yaml
+++ b/test/e2e/scale-config/chainsaw-test.yaml
@@ -3,6 +3,9 @@ kind: Test
 metadata:
   name: multi-rolegroup
 spec:
+  bindings:
+  - name: doris_version
+    value: ($values.product_version)
   steps:
   - name: install doris cluster
     try:

--- a/test/e2e/scale-config/doris.yaml
+++ b/test/e2e/scale-config/doris.yaml
@@ -5,6 +5,8 @@ metadata:
     app.kubernetes.io/name: doris-operator
   name: doriscluster-sample
 spec:
+  image:
+    productVersion: ($values.product_version)
   clusterConfig:
     scaleDownPolicy:
       backendStrategy: decommission

--- a/test/e2e/scale/chainsaw-test.yaml
+++ b/test/e2e/scale/chainsaw-test.yaml
@@ -3,6 +3,9 @@ kind: Test
 metadata:
   name: scale
 spec:
+  bindings:
+  - name: doris_version
+    value: ($values.product_version)
   steps:
   - name: install doris cluster with 1 BE replica
     try:

--- a/test/e2e/scale/doris-scaled-up.yaml
+++ b/test/e2e/scale/doris-scaled-up.yaml
@@ -5,6 +5,8 @@ metadata:
     app.kubernetes.io/name: doris-operator
   name: doriscluster-sample
 spec:
+  image:
+    productVersion: ($values.product_version)
   clusterConfig: {}
   frontend:
     roleGroups:

--- a/test/e2e/scale/doris.yaml
+++ b/test/e2e/scale/doris.yaml
@@ -5,6 +5,8 @@ metadata:
     app.kubernetes.io/name: doris-operator
   name: doriscluster-sample
 spec:
+  image:
+    productVersion: ($values.product_version)
   clusterConfig: {}
   frontend:
     roleGroups:

--- a/test/e2e/smoke/chainsaw-test.yaml
+++ b/test/e2e/smoke/chainsaw-test.yaml
@@ -4,6 +4,8 @@ metadata:
   name: logging
 spec:
   bindings:
+  - name: doris_version
+    value: ($values.product_version)
   steps:
   - name: install doris cluster
     try:

--- a/test/e2e/smoke/doris.yaml
+++ b/test/e2e/smoke/doris.yaml
@@ -6,6 +6,8 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: doriscluster-sample
 spec:
+  image:
+    productVersion: ($values.product_version)
   clusterConfig:
     vectorAggregatorConfigMapName: vector-aggregator-discovery
   frontend:


### PR DESCRIPTION
## Problem

The chainsaw e2e product-version matrix is dead, for three stacked reasons:

1. CI (`test.yml` / `release.yml`) sets a `PRODUCT_VERSION` env var per matrix leg, but chainsaw only populates `$values` from `--values` files and the `chainsaw-e2e` Makefile target never passed one — so `($values.product_version)` always resolved to `null`.
2. The e2e CR manifests never referenced `($values.product_version)` in `spec.image.productVersion` to begin with.
3. Even with a CR carrying `productVersion`, `GetImage()` (`internal/controller/common/image_helper.go`) ignored it on the official-image path, so the field was silently dropped.

Net effect: every matrix leg tested the operator's `DefaultProductVersion` regardless of what CI requested.

## Fix

- Add a `chainsaw-values` Makefile target that generates `test/e2e/.values.yaml` from `$PRODUCT_VERSION` (writes `product_version: null` when unset, preserving the default fallback for local runs), pass `--values` in `chainsaw-e2e`, and gitignore the generated file.
- Parameterize `spec.image.productVersion: ($values.product_version)` in the e2e CR manifests, with a `doris_version` binding per chainsaw-test.yaml (same pattern as zookeeper-operator).
- Make `GetImage()` resolve `apache/doris:<component>-<productVersion>` whenever `image.custom` is unset, honoring `pullPolicy`/`pullSecretName`; `image.custom` still routes through `TransformImage`. Table tests added in `image_helper_test.go`.

## Verification

- `make lint` and `make test` pass.
- Verified live in a kind cluster with the operator built from this branch: a CR with `productVersion: 2.1.9` produced StatefulSets running `apache/doris:{fe,be,broker}-2.1.9`, confirming the values → CR → StatefulSet image chain end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)