### PR TITLE
build: align tooling and gitignore with the release baseline

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,3 +37,8 @@ jobs:
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v9
+        with:
+          # Pin the linter version so a new upstream release cannot break the
+          # pipeline without a code change. Keep in sync with the Makefile's
+          # GOLANGCI_LINT_VERSION.
+          version: v2.12.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+  # Allow a manual run so the publish credentials can be verified on demand.
+  # Without this the only way to exercise them is to land a commit on main,
+  # which is how an expired HELM_CHARTS_REPO_TOKEN went unnoticed for weeks.
+  workflow_dispatch:
 
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,11 @@ jobs:
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v9
+        with:
+          # Pin the linter version so a new upstream release cannot break the
+          # pipeline without a code change. Keep in sync with the Makefile's
+          # GOLANGCI_LINT_VERSION.
+          version: v2.12.1
 
 
   golang-test:

--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,11 @@ cover.out
 .vscode
 
 docker-digests.json
+
+# helm charts
+# helm package directory
+target
+
+# ai coding
+.omc
 .worktree/


### PR DESCRIPTION
## Why

Part of the 0.4.0 release baseline alignment.

**golangci-lint was floating.** `golangci-lint-action` was invoked with no
`version:` input, so CI always installed the newest release. That breaks the
pipeline on an upstream release with no change here, and it diverges from the
v2.12.1 the Makefile already pinned.

**Two gitignore gaps.** `make helm-chart-package` writes to `target/`, which
this repo did not ignore — one of only two operators in that state. `.omc/` is
ignored in every other operator; this was the only one missing it. Both matter
now that `check-crds-sync` stages untracked files before diffing: leftover
output from a local chart or agent run gets reported as CRD drift.

**publish.yml could only be triggered by a push to main**, so its credentials
could not be verified on demand. That is how an expired `HELM_CHARTS_REPO_TOKEN`
went unnoticed for weeks — nothing landed on main to exercise it, and it only
surfaced when an unrelated change did. `workflow_dispatch` makes the publish
path verifiable before a release rather than at tag time, when the tag cannot
be recut.

## Verification

| Gate | Result |
|---|---|
| `make lint` (v2.12.1) | 0 issues |
| `make test` | all packages pass |
| `check-crds-sync` (simulated per the CI logic, clean tree) | passes |
| `make helm-crd-sync` | already in sync, no regeneration needed |
| Workflow YAML syntax | valid; `workflow_dispatch` parses as expected |

> Note: unlike most operators, doris pulls the official `apache/doris` images
> rather than kubedoop-built ones, so it has no product-version matrix to align.

🤖 Generated with [Claude Code](https://claude.com/claude-code)