### PR TITLE
ci: pin sigstore/cosign-installer to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -318,7 +318,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4


### PR DESCRIPTION
## Why

`sigstore/cosign-installer@main` was the **only unpinned action** in this
repository's release workflow. Everything else already tracks a release:

```
actions/checkout@v6              docker/login-action@v4
actions/setup-go@v6              docker/setup-buildx-action@v4
actions/setup-python@v6          docker/setup-qemu-action@v4
azure/setup-helm@v5              golangci/golangci-lint-action@v9
helm/chart-testing-action@v2.8.0 helm/kind-action@v1.14.0
sigstore/cosign-installer@main   <- the exception
```

## This is not hypothetical

The signature storage format changed underneath the release process through
exactly this path.

Older cosign published signatures as a separate `sha256-<digest>.sig` tag.
Current cosign attaches them as OCI referrers:

```
GET /v2/zncdatadev/<operator>/referrers/sha256:...
-> application/vnd.dev.sigstore.bundle.v0.3+json
```

commons-operator's registry still carries nine `.sig` tags, the newest dated
2025-10-06. That date does not mark signing stopping - it marks `@main` picking
up a new major version and switching schemes, unnoticed, between releases.

Signing works correctly today: all fifteen `0.4.0` images pass `cosign verify`.
The point is that the change was invisible until someone went looking.

The general risk for a **release** path: a third party merging to their default
branch can alter what a tagged, signed release produces - with no diff to review
here, and no way to reproduce an older release's exact behaviour.

## Change

Pin to `@v4` (latest release `v4.1.2`, 2026-05-07), matching how every other
action in this workflow is referenced.

One line. Workflow YAML validated.

> Part of a 15-repository sweep tracked in
> [kubedoop#18](https://github.com/zncdatadev/kubedoop/issues/18). Found while
> verifying 0.4.0 release artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)