### PR TITLE
fix(build): let a failed image push fail the build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- $(CONTAINER_TOOL) buildx create --name $(PROJECT_NAME)-builder
 	$(CONTAINER_TOOL) buildx use $(PROJECT_NAME)-builder
-	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --build-arg LDFLAGS=$(LDFLAGS) --tag ${IMG} --metadata-file docker-digests.json -f Dockerfile.cross .
+	$(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --build-arg LDFLAGS=$(LDFLAGS) --tag ${IMG} --metadata-file docker-digests.json -f Dockerfile.cross .
 	- $(CONTAINER_TOOL) buildx rm $(PROJECT_NAME)-builder
 	rm Dockerfile.cross
 


### PR DESCRIPTION
## What breaks

The buildx push line is prefixed with `-`, telling make to ignore a non-zero
exit. A failed push becomes a silent no-op.

`release.yml` catches it only by accident: a later cosign step reads
`docker-digests.json` and dies because the file was never written.

```
ERROR: failed to push quay.io/zncdatadev/nifi-operator:0.4.0-dev: 401 UNAUTHORIZED
make: [Makefile:155: docker-buildx] Error 1 (ignored)
jq: error: Could not open file docker-digests.json: No such file or directory
```

`publish.yml` has **no cosign step**, so nothing notices. The push fails, make
swallows it, the job reports **success**.

This is not theoretical: nifi-operator's `Publish Image` reported success on
2026-08-19 while `quay.io/zncdatadev/nifi-operator` did not exist and every push
had been returning 401. The registry had zero tags. It surfaced only when a
tagged release ran the cosign step.

## Change

Drop the `-` on the push line.

It is deliberately **kept** on `buildx create` and `buildx rm`, where tolerating
failure is correct — `create` fails when the builder already exists, and `rm` is
cleanup.

```diff
-	- $(CONTAINER_TOOL) buildx build --push ... -f Dockerfile.cross .
+	$(CONTAINER_TOOL) buildx build --push ... -f Dockerfile.cross .
```

Makefile parse-checked.

> Part of a 15-repository sweep tracked in
> [kubedoop#16](https://github.com/zncdatadev/kubedoop/issues/16). Found while
> verifying 0.4.0 release artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)